### PR TITLE
Add Tags and Events annotation classes

### DIFF
--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -27,6 +27,7 @@ class Tags(Annotation):
         self.labels = labels
         self.confidence = confidence
 
+
 class Events(Annotation):
     """Events class
 
@@ -38,6 +39,7 @@ class Events(Annotation):
         confidence (np.ndarray or None): array of float confidence values
             in the range [0, 1]
     """
+
     def __init__(self, intervals, labels, confidence=None) -> None:
         validate_array_like(intervals, np.ndarray, float)
         validate_array_like(labels, list, str)

--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -22,6 +22,8 @@ class Tags(Annotation):
     def __init__(self, labels, confidence=None) -> None:
         validate_array_like(labels, list, str)
         validate_array_like(confidence, np.ndarray, float, none_allowed=True)
+        validate_confidence(confidence)
+        validate_lengths_equal([labels, confidence])
         self.labels = labels
         self.confidence = confidence
 

--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -12,6 +12,40 @@ class Annotation(object):
         return repr_str
 
 
+class Tags(Annotation):
+    """Tags class
+
+    Attributes:
+        tags (list): list of tags (strings)
+    """
+
+    def __init__(self, tags, confidence=None) -> None:
+        validate_array_like(tags, list, str)
+        validate_array_like(confidence, np.ndarray, float, none_allowed=True)
+        self.tags = tags
+        self.confidence = confidence
+
+class Events(Annotation):
+    """Events class
+
+    Parameters
+    ----------
+    Annotation : [type]
+        [description]
+    """
+    def __init__(self, intervals, labels, confidence=None) -> None:
+        validate_array_like(intervals, np.ndarray, float)
+        validate_array_like(labels, np.ndarray, str)
+        validate_array_like(confidence, np.ndarray, float, none_allowed=True)
+        validate_lengths_equal([intervals, labels, confidence])
+        validate_intervals(intervals)
+        validate_confidence(confidence)
+
+        self.intervals = intervals
+        self.labels = labels
+        self.confidence = confidence
+
+
 class BeatData(Annotation):
     """BeatData class
 

--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -28,14 +28,17 @@ class Tags(Annotation):
 class Events(Annotation):
     """Events class
 
-    Parameters
-    ----------
-    Annotation : [type]
-        [description]
+    Attributes:
+        intervals (np.ndarray): (n x 2) array of intervals
+            (as floats) in seconds in the form [start_time, end_time]
+            with positive time stamps and end_time >= start_time.
+        labels (list): list of event labels (as strings)
+        confidence (np.ndarray or None): array of float confidence values
+            in the range [0, 1]
     """
     def __init__(self, intervals, labels, confidence=None) -> None:
         validate_array_like(intervals, np.ndarray, float)
-        validate_array_like(labels, np.ndarray, str)
+        validate_array_like(labels, list, str)
         validate_array_like(confidence, np.ndarray, float, none_allowed=True)
         validate_lengths_equal([intervals, labels, confidence])
         validate_intervals(intervals)

--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -16,13 +16,13 @@ class Tags(Annotation):
     """Tags class
 
     Attributes:
-        tags (list): list of tags (strings)
+        labels (list): list of string tags
     """
 
-    def __init__(self, tags, confidence=None) -> None:
-        validate_array_like(tags, list, str)
+    def __init__(self, labels, confidence=None) -> None:
+        validate_array_like(labels, list, str)
         validate_array_like(confidence, np.ndarray, float, none_allowed=True)
-        self.tags = tags
+        self.labels = labels
         self.confidence = confidence
 
 class Events(Annotation):

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -20,6 +20,27 @@ def test_repr():
     assert beat_data.__repr__() == "BeatData(positions, times)"
 
 
+def test_events():
+    # test good data
+    intervals = np.array([[1.0, 2.0], [1.5, 3.0], [2.0, 3.0]])
+    labels = ["Siren", "Laughter", "Engine"]
+    confidence = np.array([1, 0.5, 0.2])
+    events = annotations.Events(intervals, labels, confidence)
+    assert np.allclose(events.intervals, intervals)
+    assert events.labels == labels
+    assert np.allclose(events.confidence, confidence)
+
+    # test bad data
+    bad_intervals = np.array([[1.0, 0.0], [1.5, 3.0], [2.0, 3.0]])
+    pytest.raises(ValueError, annotations.Events, bad_intervals, labels, confidence)
+
+    bad_labels = ["Siren", "Laughter", 5]
+    pytest.raises(TypeError, annotations.Events, intervals, bad_labels, confidence)
+
+    bad_confidence = np.array([1, 0.5, -0.2])
+    pytest.raises(ValueError, annotations.Events, intervals, labels, bad_confidence)
+
+
 def test_beat_data():
     times = np.array([1.0, 2.0])
     positions = np.array([3, 4])

--- a/tests/test_annotations.py
+++ b/tests/test_annotations.py
@@ -20,6 +20,22 @@ def test_repr():
     assert beat_data.__repr__() == "BeatData(positions, times)"
 
 
+def test_tags():
+    # test good data
+    labels = ["Siren", "Laughter", "Engine"]
+    confidence = np.array([1, 0.5, 0.2])
+    tags = annotations.Tags(labels, confidence)
+    assert tags.labels == labels
+    assert np.allclose(tags.confidence, confidence)
+
+    # test bad data
+    bad_labels = ["Siren", "Laughter", 5]
+    pytest.raises(TypeError, annotations.Tags, bad_labels, confidence)
+
+    bad_confidence = np.array([1, 0.5, -0.2])
+    pytest.raises(ValueError, annotations.Tags, labels, bad_confidence)
+
+
 def test_events():
     # test good data
     intervals = np.array([[1.0, 2.0], [1.5, 3.0], [2.0, 3.0]])

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ extras =
   tests
   dali
 commands =
-  pytest --cov-report=xml --cov=soundata {toxinidir}/tests/
+  pytest --cov-report term-missing --cov-report=xml --cov=soundata {toxinidir}/tests/
 
 [testenv:check-formatting]
 basepython=python3.8


### PR DESCRIPTION
We need new classes for soundata. Based on offline discussion with @magdalenafuentes we believe we only need two classes:
* Tags: a list of string labels and corresponding confidences. No time intervals.
* Events: sound events represented as time intervals + labels + confidence.

These should cover the different DCASE tasks:
* ASC --> tags
* SEC --> tags
* SED (strong) --> events
* SED (weak) --> tags

This PR implements the Tags and Events classes along with corresponding unit tests