### PR TITLE
Refactor MultiTrack into ClipGroup

### DIFF
--- a/soundata/core.py
+++ b/soundata/core.py
@@ -261,7 +261,10 @@ class Dataset(object):
             NotImplementedError: If the dataset does not support Clipgroups
 
         """
-        return {clipgroup_id: self.clipgroup(clipgroup_id) for clipgroup_id in self.clipgroup_ids}
+        return {
+            clipgroup_id: self.clipgroup(clipgroup_id)
+            for clipgroup_id in self.clipgroup_ids
+        }
 
     def choice_clip(self):
         """Choose a random clip
@@ -504,7 +507,9 @@ class ClipGroup(Clip):
         """
         if clipgroup_id not in index["clipgroups"]:
             raise ValueError(
-                "{} is not a valid clipgroup_id in {}".format(clipgroup_id, dataset_name)
+                "{} is not a valid clipgroup_id in {}".format(
+                    clipgroup_id, dataset_name
+                )
             )
 
         self.clipgroup_id = clipgroup_id

--- a/soundata/datasets/indexes/beatles_index.json
+++ b/soundata/datasets/indexes/beatles_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.2",
-  "tracks": {
+  "clips": {
     "0201": {
       "audio": [
         "audio/02_-_With_the_Beatles/01_-_It_Won't_Be_Long.wav",

--- a/soundata/datasets/indexes/beatport_key_index.json
+++ b/soundata/datasets/indexes/beatport_key_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "tracks": {
+  "clips": {
     "1": {
       "audio": [
         "audio/100066 Lindstrom - Monsteer (Original Mix).mp3",

--- a/soundata/datasets/indexes/billboard_index.json
+++ b/soundata/datasets/indexes/billboard_index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "tracks": {
+  "clips": {
     "3": {
       "audio": [
         "audio/1960s/James Brown/I Don't Mind/audio.flac",

--- a/soundata/datasets/indexes/cante100_index.json
+++ b/soundata/datasets/indexes/cante100_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "tracks": {
+  "clips": {
     "001": {
       "audio": [
         "cante100audio/001_FernandoTerremoto_Fandangos.mp3",

--- a/soundata/datasets/indexes/compmusic_otmm_makam_index.json
+++ b/soundata/datasets/indexes/compmusic_otmm_makam_index.json
@@ -1,6 +1,6 @@
 {
   "version": "dlfm2016",
-  "tracks": {
+  "clips": {
     "cafcdeaf-e966-4ff0-84fb-f660d2b68365": {
       "metadata": [
         "MTG-otmm_makam_recognition_dataset-f14c0d0/data/Kurdilihicazkar/cafcdeaf-e966-4ff0-84fb-f660d2b68365.json",

--- a/soundata/datasets/indexes/dali_index.json
+++ b/soundata/datasets/indexes/dali_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "tracks": {
+  "clips": {
     "001940b614eb43f4a0c826d49a67d66d": {
       "audio": [
         "audio/001940b614eb43f4a0c826d49a67d66d.mp3",

--- a/soundata/datasets/indexes/giantsteps_key_index.json
+++ b/soundata/datasets/indexes/giantsteps_key_index.json
@@ -1,6 +1,6 @@
 {
   "version": "+",
-  "tracks": {
+  "clips": {
     "1": {
       "audio": [
         "audio/1004923 Kaiserdisco - Carachillo (Original Mix).mp3",

--- a/soundata/datasets/indexes/giantsteps_tempo_index.json
+++ b/soundata/datasets/indexes/giantsteps_tempo_index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "tracks": {
+  "clips": {
     "0": {
       "audio": [
         "audio/1030011.LOFI.mp3",

--- a/soundata/datasets/indexes/groove_midi_index.json
+++ b/soundata/datasets/indexes/groove_midi_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0.0",
-  "tracks": {
+  "clips": {
     "drummer1/eval_session/1": {
       "midi": [
         "drummer1/eval_session/1_funk-groove1_138_beat_4-4.mid",

--- a/soundata/datasets/indexes/gtzan_genre_index.json
+++ b/soundata/datasets/indexes/gtzan_genre_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
     "classical.00000": {
       "audio": [
         "gtzan_genre/genres/classical/classical.00000.wav",

--- a/soundata/datasets/indexes/guitarset_index.json
+++ b/soundata/datasets/indexes/guitarset_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.1.0",
-  "tracks": {
+  "clips": {
     "00_BN1-129-Eb_comp": {
       "audio_hex_cln": [
         "audio_hex-pickup_debleeded/00_BN1-129-Eb_comp_hex_cln.wav",

--- a/soundata/datasets/indexes/ikala_index.json
+++ b/soundata/datasets/indexes/ikala_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
     "10161_chorus": {
       "audio": [
         "Wavfile/10161_chorus.wav",

--- a/soundata/datasets/indexes/irmas_index.json
+++ b/soundata/datasets/indexes/irmas_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "tracks": {
+  "clips": {
     "0001__1": {
       "audio": [
         "IRMAS-TrainingData/cel/[cel][cla]0001__1.wav",

--- a/soundata/datasets/indexes/maestro_index.json
+++ b/soundata/datasets/indexes/maestro_index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0.0",
-  "tracks": {
+  "clips": {
     "2018/MIDI-Unprocessed_Chamber3_MID--AUDIO_10_R3_2018_wav--1": {
       "midi": [
         "2018/MIDI-Unprocessed_Chamber3_MID--AUDIO_10_R3_2018_wav--1.midi",

--- a/soundata/datasets/indexes/medleydb_melody_index.json
+++ b/soundata/datasets/indexes/medleydb_melody_index.json
@@ -1,6 +1,6 @@
 {
   "version": "5.0",
-  "tracks": {
+  "clips": {
     "AClassicEducation_NightOwl": {
       "audio": [
         "audio/AClassicEducation_NightOwl_MIX.wav",

--- a/soundata/datasets/indexes/medleydb_pitch_index.json
+++ b/soundata/datasets/indexes/medleydb_pitch_index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0",
-  "tracks": {
+  "clips": {
     "AClassicEducation_NightOwl_STEM_08": {
       "audio": [
         "audio/AClassicEducation_NightOwl_STEM_08.wav",

--- a/soundata/datasets/indexes/mridangam_stroke_index.json
+++ b/soundata/datasets/indexes/mridangam_stroke_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.5",
-  "tracks": {
+  "clips": {
     "224030": {
       "audio": [
         "mridangam_stroke_1.5/B/224030__akshaylaya__bheem-b-001.wav",

--- a/soundata/datasets/indexes/orchset_index.json
+++ b/soundata/datasets/indexes/orchset_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "tracks": {
+  "clips": {
     "Beethoven-S3-I-ex1": {
       "audio_stereo": [
         "audio/stereo/Beethoven-S3-I-ex1.wav",

--- a/soundata/datasets/indexes/phenicx_anechoic_index.json
+++ b/soundata/datasets/indexes/phenicx_anechoic_index.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
-  "tracks": {
+  "clips": {
     "beethoven-horn": {
       "audio_horn1": [
         "audio/beethoven/horn1.wav",
@@ -778,9 +778,9 @@
       ]
     }
   },
-  "multitracks": {
+  "clipgroups": {
     "beethoven": {
-      "tracks": [
+      "clips": [
         "beethoven-horn",
         "beethoven-doublebass",
         "beethoven-violin",
@@ -794,7 +794,7 @@
       ]
     },
     "bruckner": {
-      "tracks": [
+      "clips": [
         "bruckner-horn",
         "bruckner-doublebass",
         "bruckner-violin",
@@ -808,7 +808,7 @@
       ]
     },
     "mahler": {
-      "tracks": [
+      "clips": [
         "mahler-horn",
         "mahler-doublebass",
         "mahler-violin",
@@ -822,7 +822,7 @@
       ]
     },
     "mozart": {
-      "tracks": [
+      "clips": [
         "mozart-horn",
         "mozart-doublebass",
         "mozart-violin",

--- a/soundata/datasets/indexes/rwc_classical_index.json
+++ b/soundata/datasets/indexes/rwc_classical_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
     "RM-C001": {
       "audio": [
         "audio/rwc-c-m01/1.wav",

--- a/soundata/datasets/indexes/rwc_jazz_index.json
+++ b/soundata/datasets/indexes/rwc_jazz_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
     "RM-J001": {
       "audio": [
         "audio/rwc-j-m01/1.wav",

--- a/soundata/datasets/indexes/rwc_popular_index.json
+++ b/soundata/datasets/indexes/rwc_popular_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
     "RM-P001": {
       "audio": [
         "audio/rwc-p-m01/1.wav",

--- a/soundata/datasets/indexes/salami_index.json
+++ b/soundata/datasets/indexes/salami_index.json
@@ -1,6 +1,6 @@
 {
   "version": "2.0-corrected",
-  "tracks": {
+  "clips": {
     "602": {
       "annotator_1_lowercase": [
         "salami-data-public-hierarchy-corrections/annotations/602/parsed/textfile1_lowercase.txt",

--- a/soundata/datasets/indexes/saraga_carnatic_index.json
+++ b/soundata/datasets/indexes/saraga_carnatic_index.json
@@ -1,6 +1,6 @@
 {
   "version": 1.5,
-  "tracks": {
+  "clips": {
     "0_Dorakuna": {
       "audio-mix": [
         "saraga1.5_carnatic/Sumitra Nitin at Arkay by Sumitra Nitin/Dorakuna/Dorakuna.mp3.mp3",

--- a/soundata/datasets/indexes/saraga_hindustani_index.json
+++ b/soundata/datasets/indexes/saraga_hindustani_index.json
@@ -1,6 +1,6 @@
 {
   "version": 1.5,
-  "tracks": {
+  "clips": {
     "0_Raag_Shree": {
       "audio": [
         "saraga1.5_hindustani/Raag Shree by Deborshee Bhattacharya/Raag Shree/Raag Shree.mp3.mp3",

--- a/soundata/datasets/indexes/tinysol_index.json
+++ b/soundata/datasets/indexes/tinysol_index.json
@@ -1,6 +1,6 @@
 {
   "version": "6.0",
-  "tracks": {
+  "clips": {
     "BTb-ord-F#1-pp-N-N": {
       "audio": [
         "audio/Brass/Bass_Tuba/ordinario/BTb-ord-F#1-pp-N-N.wav",

--- a/soundata/datasets/indexes/tonality_classicaldb_index.json
+++ b/soundata/datasets/indexes/tonality_classicaldb_index.json
@@ -1,6 +1,6 @@
 {
   "version": "1.0",
-  "tracks": {
+  "clips": {
       "0": {
         "audio": [
           "audio/01-Allegro__Gloria_in_excelsis_Deo_in_D_Major - D.wav",

--- a/soundata/datasets/phenicx_anechoic.py
+++ b/soundata/datasets/phenicx_anechoic.py
@@ -220,8 +220,8 @@ class Clip(core.Clip):
         )
 
 
-class MultiTrack(core.MultiTrack):
-    """Phenicx-Anechoic MultiTrack class
+class ClipGroup(core.ClipGroup):
+    """Phenicx-Anechoic ClipGroup class
 
     Args:
         mclip_id (str): track id of the track
@@ -418,7 +418,7 @@ class Dataset(core.Dataset):
             data_home,
             name="phenicx_anechoic",
             clip_class=Clip,
-            multitrack_class=MultiTrack,
+            clipgroup_class=ClipGroup,
             bibtex=BIBTEX,
             remotes=REMOTES,
             license_info=LICENSE_INFO,

--- a/soundata/validate.py
+++ b/soundata/validate.py
@@ -76,14 +76,14 @@ def validate_files(file_dict, data_home, verbose):
     missing = {}
     invalid = {}
     for file_id, file in tqdm.tqdm(file_dict.items(), disable=not verbose):
-        for tracks in file.keys():
-            # multitrack case
-            if tracks == "tracks":
+        for clips in file.keys():
+            # clipgroup case
+            if clips == "clips":
                 continue
-            # tracks
+            # clips
             else:
-                filepath = file[tracks][0]
-                checksum = file[tracks][1]
+                filepath = file[clips][0]
+                checksum = file[clips][1]
                 if filepath is not None:
                     local_path = os.path.join(data_home, filepath)
                     exists, valid = validate(local_path, checksum)
@@ -158,23 +158,23 @@ def validate_index(dataset_index, data_home, verbose=True):
         missing_files["metadata"] = missing_metadata
         invalid_checksums["metadata"] = invalid_metadata
 
-    if "tracks" in dataset_index and dataset_index["tracks"] is not None:
-        missing_tracks, invalid_tracks = validate_files(
-            dataset_index["tracks"],
+    if "clips" in dataset_index and dataset_index["clips"] is not None:
+        missing_clips, invalid_clips = validate_files(
+            dataset_index["clips"],
             data_home,
             verbose,
         )
-        missing_files["tracks"] = missing_tracks
-        invalid_checksums["tracks"] = invalid_tracks
+        missing_files["clips"] = missing_clips
+        invalid_checksums["clips"] = invalid_clips
 
-    if "multitracks" in dataset_index and dataset_index["multitracks"] is not None:
-        missing_multitracks, invalid_multitracks = validate_files(
-            dataset_index["multitracks"],
+    if "clipgroups" in dataset_index and dataset_index["clipgroups"] is not None:
+        missing_clipgroups, invalid_clipgroups = validate_files(
+            dataset_index["clipgroups"],
             data_home,
             verbose,
         )
-        missing_files["multitracks"] = missing_multitracks
-        invalid_checksums["multitracks"] = invalid_multitracks
+        missing_files["clipgroups"] = missing_clipgroups
+        invalid_checksums["clipgroups"] = invalid_clipgroups
 
     return missing_files, invalid_checksums
 

--- a/tests/indexes/test_index_invalid_checksum.json
+++ b/tests/indexes/test_index_invalid_checksum.json
@@ -1,5 +1,5 @@
 { "version": null,
-  "tracks": {
+  "clips": {
     "10161_chorus": {
       "audio": [
         "10161_chorus.wav",

--- a/tests/indexes/test_index_missing_file.json
+++ b/tests/indexes/test_index_missing_file.json
@@ -1,5 +1,5 @@
 { "version": null,
-  "tracks": {
+  "clips": {
     "10161_chorus": {
       "audio": [
         "10162_chorus.wav",

--- a/tests/indexes/test_index_valid.json
+++ b/tests/indexes/test_index_valid.json
@@ -1,5 +1,5 @@
 { "version": null,
-  "tracks": {
+  "clips": {
     "10161_chorus": {
       "audio": [
         "10161_chorus.wav",

--- a/tests/resources/mir_datasets/acousticbrainz_genre/acousticbrainz_genre_index.json
+++ b/tests/resources/mir_datasets/acousticbrainz_genre/acousticbrainz_genre_index.json
@@ -1,6 +1,6 @@
 {
   "version": null,
-  "tracks": {
+  "clips": {
       "tagtraum#validation#be9e01e5-8f93-494d-bbaa-ddcc5a52f629#2b6bfcfd-46a5-3f98-a58f-2c51d7c9e960#trance########": {
         "data": [
           "acousticbrainz-mediaeval-validation/be/be9e01e5-8f93-494d-bbaa-ddcc5a52f629.json",

--- a/tests/resources/mir_datasets/cante100/cante100_README.txt
+++ b/tests/resources/mir_datasets/cante100/cante100_README.txt
@@ -10,7 +10,7 @@ Universitat Pompeu Fabra
 
 
 ===== INTRODUCTION ======
-The cante100 dataset contains 100 track taken from corpusCofla. Manual annotations include style family (10 different style families with 10 tracks each) and vocal sections. cante100 is a representative subsample of the full research corpus. All manual and automatic annotations as well as meta-information are publicly available for download. The full audio files are available on request for research purposes only. 
+The cante100 dataset contains 100 track taken from corpusCofla. Manual annotations include style family (10 different style families with 10 clips each) and vocal sections. cante100 is a representative subsample of the full research corpus. All manual and automatic annotations as well as meta-information are publicly available for download. The full audio files are available on request for research purposes only. 
 
 
 ===== CONTACT ======
@@ -74,7 +74,7 @@ dbanez@us.es
 
 
 ===== META-DATA ANNOTATIONS =====
-- XML file containing entries for all tracks
+- XML file containing entries for all clips
 - source: anthology name, CD no. and track no. 
 - editorial meta data: artist, title, style, duration min. and duration sec. 
 - MusicBrainzID (see www.musicbrainz.org)

--- a/tests/test_beatles.py
+++ b/tests/test_beatles.py
@@ -2,14 +2,14 @@ import numpy as np
 
 from soundata.datasets import beatles
 from soundata import annotations
-from tests.test_utils import run_track_tests
+from tests.test_utils import run_clip_tests
 
 
-def test_track():
-    default_trackid = "0111"
+def test_clip():
+    default_clipid = "0111"
     data_home = "tests/resources/mir_datasets/beatles"
     dataset = beatles.Dataset(data_home)
-    track = dataset.clip(default_trackid)
+    clip = dataset.clip(default_clipid)
 
     expected_attributes = {
         "audio_path": "tests/resources/mir_datasets/beatles/"
@@ -34,27 +34,27 @@ def test_track():
         "audio": tuple,
     }
 
-    run_track_tests(track, expected_attributes, expected_property_types)
+    run_clip_tests(clip, expected_attributes, expected_property_types)
 
-    audio, sr = track.audio
+    audio, sr = clip.audio
     assert sr == 44100, "sample rate {} is not 44100".format(sr)
     assert audio.shape == (44100 * 2,), "audio shape {} was not (88200,)".format(
         audio.shape
     )
 
-    track = dataset.clip("10212")
-    assert track.beats is None, "expected track.beats to be None, got {}".format(
-        track.beats
+    clip = dataset.clip("10212")
+    assert clip.beats is None, "expected clip.beats to be None, got {}".format(
+        clip.beats
     )
-    assert track.key is None, "expected track.key to be None, got {}".format(track.key)
+    assert clip.key is None, "expected clip.key to be None, got {}".format(clip.key)
 
 
 def test_to_jams():
 
     data_home = "tests/resources/mir_datasets/beatles"
     dataset = beatles.Dataset(data_home)
-    track = dataset.clip("0111")
-    jam = track.to_jams()
+    clip = dataset.clip("0111")
+    jam = clip.to_jams()
 
     beats = jam.search(namespace="beat")[0]["data"]
     assert [beat.time for beat in beats] == [

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -143,7 +143,7 @@ def test_clipgroup_repr():
     expected1 = """Clip(\n  a="asdf",\n  b=1.2345678,\n  """
     expected2 = """c={1: \'a\', \'b\': 2},\n  clip_ids=[\'a\', \'b\', \'c\'],\n  """
     expected3 = """clipgroup_id="test",\n  e=None,\n  """
-    expected4 = """long="...{}",\n  """.format("b"*50 + "c" * 50)
+    expected4 = """long="...{}",\n  """.format("b" * 50 + "c" * 50)
     expected5 = """clip_audio_property: ,\n  clips: ,\n  f: ThisObjectType,\n  """
     expected6 = """g: I have an improper docstring,\n)"""
 
@@ -273,7 +273,12 @@ def test_clipgroup():
     metadata_none = lambda: None
 
     clipgroup_metadata_cidx = core.ClipGroup(
-        clipgroup_id, data_home, dataset_name, index, core.Clip, metadata_clipgroup_index
+        clipgroup_id,
+        data_home,
+        dataset_name,
+        index,
+        core.Clip,
+        metadata_clipgroup_index,
     )
     assert clipgroup_metadata_cidx._clipgroup_metadata == {"x": 1, "y": 2, "z": 3}
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -7,7 +7,7 @@ from soundata import core
 
 def test_clip():
     index = {
-        "tracks": {
+        "clips": {
             "a": {
                 "audio": (None, None),
                 "annotation": ("asdf/asdd", "asdfasdfasdfasdf"),
@@ -99,26 +99,26 @@ def test_clip_repr():
         test_clip.to_jams()
 
 
-def test_multitrack_repr():
-    class TestTrack(core.Clip):
+def test_clipgroup_repr():
+    class TestClip(core.Clip):
         def __init__(self):
             self.a = "asdf"
 
-    class TestMultiTrack(core.MultiTrack):
-        def __init__(self, mtrack_id, data_home):
+    class TestClipGroup(core.ClipGroup):
+        def __init__(self, clipgroup_id, data_home):
             self.a = "asdf"
             self.b = 1.2345678
             self.c = {1: "a", "b": 2}
             self._d = "hidden"
             self.e = None
             self.long = "a" + "b" * 50 + "c" * 50
-            self.mtrack_id = mtrack_id
+            self.clipgroup_id = clipgroup_id
             self._data_home = data_home
             self._dataset_name = "foo"
             self._index = None
             self._metadata = None
-            self._track_class = TestTrack
-            self.track_ids = ["a", "b", "c"]
+            self._clip_class = TestClip
+            self.clip_ids = ["a", "b", "c"]
 
         @property
         def f(self):
@@ -133,21 +133,28 @@ def test_multitrack_repr():
         def h(self):
             return "I'm a function!"
 
-    expected1 = """Clip(\n  a="asdf",\n  b=1.2345678,\n  """
-    expected2 = """c={1: \'a\', \'b\': 2},\n  e=None,\n  """
-    expected3 = """long="...{}",\n  """.format("b" * 50 + "c" * 50)
-    expected4 = """mtrack_id="test",\n  track_ids=[\'a\', \'b\', \'c\'],\n  """
-    expected5 = """f: ThisObjectType,\n  g: I have an improper docstring,\n  """
-    expected6 = """track_audio_property: ,\n  tracks: ,\n)"""
+    # expected1 = """Clip(\n  a="asdf",\n  b=1.2345678,\n  """
+    # expected2 = """c={1: \'a\', \'b\': 2},\n  e=None,\n  """
+    # expected3 = """long="...{}",\n  """.format("b" * 50 + "c" * 50)
+    # expected4 = """clipgroup_id="test",\n  clip_ids=[\'a\', \'b\', \'c\'],\n  """
+    # expected5 = """f: ThisObjectType,\n  g: I have an improper docstring,\n  """
+    # expected6 = """clip_audio_property: ,\n  clips: ,\n)"""
 
-    test_mtrack = TestMultiTrack("test", "foo")
-    actual = test_mtrack.__repr__()
+    expected1 = """Clip(\n  a="asdf",\n  b=1.2345678,\n  """
+    expected2 = """c={1: \'a\', \'b\': 2},\n  clip_ids=[\'a\', \'b\', \'c\'],\n  """
+    expected3 = """clipgroup_id="test",\n  e=None,\n  """
+    expected4 = """long="...{}",\n  """.format("b"*50 + "c" * 50)
+    expected5 = """clip_audio_property: ,\n  clips: ,\n  f: ThisObjectType,\n  """
+    expected6 = """g: I have an improper docstring,\n)"""
+
+    test_clipgroup = TestClipGroup("test", "foo")
+    actual = test_clipgroup.__repr__()
     assert (
         actual == expected1 + expected2 + expected3 + expected4 + expected5 + expected6
     )
 
     with pytest.raises(NotImplementedError):
-        test_mtrack.to_jams()
+        test_clipgroup.to_jams()
 
 
 def test_dataset():
@@ -171,24 +178,24 @@ def test_dataset_errors():
         soundata.initialize("not_a_dataset")
 
     d = soundata.initialize("orchset")
-    d._track_class = None
+    d._clip_class = None
     with pytest.raises(AttributeError):
-        d.track("asdf")
+        d.clip("asdf")
 
     with pytest.raises(AttributeError):
-        d.multitrack("asdf")
+        d.clipgroup("asdf")
 
     with pytest.raises(AttributeError):
-        d.load_tracks()
+        d.load_clips()
 
     with pytest.raises(AttributeError):
-        d.load_multitracks()
+        d.load_clipgroups()
 
     with pytest.raises(AttributeError):
-        d.choice_track()
+        d.choice_clip()
 
     with pytest.raises(AttributeError):
-        d.choice_multitrack()
+        d.choice_clipgroup()
 
     d = soundata.initialize("acousticbrainz_genre")
     with pytest.raises(FileNotFoundError):
@@ -196,12 +203,12 @@ def test_dataset_errors():
 
     d = soundata.initialize("phenicx_anechoic")
     with pytest.raises(ValueError):
-        d._multitrack("a")
+        d._clipgroup("a")
 
 
-def test_multitrack():
-    index_tracks = {
-        "tracks": {
+def test_clipgroup():
+    index_clips = {
+        "clips": {
             "a": {
                 "audio": (None, None),
                 "annotation": ("asdf/asdd", "asdfasdfasdfasdf"),
@@ -212,77 +219,77 @@ def test_multitrack():
             },
         }
     }
-    index_mtracks = {
-        "multitracks": {
+    index_clipgroups = {
+        "clipgroups": {
             "ab": {
-                "tracks": ["a", "b"],
+                "clips": ["a", "b"],
                 "audio_master": ("foo/bar", "asdfasdfasdfasdf"),
                 "score": (None, None),
             }
         }
     }
     index = {}
-    index.update(index_tracks)
-    index.update(index_mtracks)
-    mtrack_id = "ab"
+    index.update(index_clips)
+    index.update(index_clipgroups)
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = core.MultiTrack(
-        mtrack_id, data_home, dataset_name, index, core.Clip, lambda: None
+    clipgroup = core.ClipGroup(
+        clipgroup_id, data_home, dataset_name, index, core.Clip, lambda: None
     )
 
-    path_good = mtrack.get_path("audio_master")
+    path_good = clipgroup.get_path("audio_master")
     assert path_good == "tests/resources/mir_datasets/foo/bar"
-    path_none = mtrack.get_path("score")
+    path_none = clipgroup.get_path("score")
     assert path_none is None
 
-    assert mtrack.mtrack_id == mtrack_id
-    assert mtrack._dataset_name == dataset_name
-    assert mtrack._data_home == data_home
-    assert list(mtrack.tracks.keys()) == ["a", "b"]
+    assert clipgroup.clipgroup_id == clipgroup_id
+    assert clipgroup._dataset_name == dataset_name
+    assert clipgroup._data_home == data_home
+    assert list(clipgroup.clips.keys()) == ["a", "b"]
 
-    assert mtrack._metadata() is None
+    assert clipgroup._metadata() is None
     with pytest.raises(AttributeError):
-        mtrack._multitrack_metadata
+        clipgroup._clipgroup_metadata
 
     with pytest.raises(NotImplementedError):
-        mtrack.to_jams()
+        clipgroup.to_jams()
 
     with pytest.raises(KeyError):
-        mtrack.get_target(["c"])
+        clipgroup.get_target(["c"])
 
     with pytest.raises(NotImplementedError):
-        mtrack.get_random_target()
+        clipgroup.get_random_target()
 
     with pytest.raises(NotImplementedError):
-        mtrack.get_mix()
+        clipgroup.get_mix()
 
     with pytest.raises(NotImplementedError):
-        mtrack.track_audio_property
+        clipgroup.clip_audio_property
 
-    # tracks with metadata
-    metadata_mtrack_index = lambda: {"ab": {"x": 1, "y": 2, "z": 3}}
+    # clips with metadata
+    metadata_clipgroup_index = lambda: {"ab": {"x": 1, "y": 2, "z": 3}}
     metadata_global = lambda: {"asdf": [1, 2, 3], "asdd": [4, 5, 6]}
     metadata_none = lambda: None
 
-    mtrack_metadata_tidx = core.MultiTrack(
-        mtrack_id, data_home, dataset_name, index, core.Clip, metadata_mtrack_index
+    clipgroup_metadata_cidx = core.ClipGroup(
+        clipgroup_id, data_home, dataset_name, index, core.Clip, metadata_clipgroup_index
     )
-    assert mtrack_metadata_tidx._multitrack_metadata == {"x": 1, "y": 2, "z": 3}
+    assert clipgroup_metadata_cidx._clipgroup_metadata == {"x": 1, "y": 2, "z": 3}
 
-    mtrack_metadata_global = core.MultiTrack(
-        mtrack_id, data_home, dataset_name, index, core.Clip, metadata_global
+    clipgroup_metadata_global = core.ClipGroup(
+        clipgroup_id, data_home, dataset_name, index, core.Clip, metadata_global
     )
-    assert mtrack_metadata_global._multitrack_metadata == {
+    assert clipgroup_metadata_global._clipgroup_metadata == {
         "asdf": [1, 2, 3],
         "asdd": [4, 5, 6],
     }
 
-    mtrack_metadata_none = core.MultiTrack(
-        mtrack_id, data_home, dataset_name, index, core.Clip, metadata_none
+    clipgroup_metadata_none = core.ClipGroup(
+        clipgroup_id, data_home, dataset_name, index, core.Clip, metadata_none
     )
     with pytest.raises(AttributeError):
-        mtrack_metadata_none._multitrack_metadata
+        clipgroup_metadata_none._clipgroup_metadata
 
     class TestTrack(core.Clip):
         def __init__(
@@ -294,10 +301,10 @@ def test_multitrack():
         def f(self):
             return np.random.uniform(-1, 1, (2, 100)), 1000
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestMultiTrack1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -305,7 +312,7 @@ def test_multitrack():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -317,16 +324,16 @@ def test_multitrack():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
     # import pdb;pdb.set_trace()
-    mtrack = TestMultiTrack1(
-        mtrack_id, data_home, dataset_name, index, TestTrack, lambda: None
+    clipgroup = TestMultiTrack1(
+        clipgroup_id, data_home, dataset_name, index, TestTrack, lambda: None
     )
-    mtrack.to_jams()
-    mtrack.get_target(["a"])
-    mtrack.get_random_target()
+    clipgroup.to_jams()
+    clipgroup.get_target(["a"])
+    clipgroup.get_random_target()
 
 
 def test_multitrack_mixing():
@@ -340,10 +347,10 @@ def test_multitrack_mixing():
         def f(self):
             return np.random.uniform(-1, 1, (2, 100)), 1000
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestMultiTrack1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -351,7 +358,7 @@ def test_multitrack_mixing():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -363,38 +370,38 @@ def test_multitrack_mixing():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
-    index = {"multitracks": {"ab": {"tracks": ["a", "b", "c"]}}}
-    mtrack_id = "ab"
+    index = {"clipgroups": {"ab": {"clips": ["a", "b", "c"]}}}
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = TestMultiTrack1(
-        mtrack_id, data_home, dataset_name, index, TestTrack, lambda: None
+    clipgroup = TestMultiTrack1(
+        clipgroup_id, data_home, dataset_name, index, TestTrack, lambda: None
     )
 
-    target1 = mtrack.get_target(["a", "c"])
+    target1 = clipgroup.get_target(["a", "c"])
     assert target1.shape == (2, 100)
     assert np.max(np.abs(target1)) <= 1
 
-    target2 = mtrack.get_target(["b", "c"], weights=[0.5, 0.2])
+    target2 = clipgroup.get_target(["b", "c"], weights=[0.5, 0.2])
     assert target2.shape == (2, 100)
     assert np.max(np.abs(target2)) <= 1
 
-    target3 = mtrack.get_target(["b", "c"], weights=[0.5, 5])
+    target3 = clipgroup.get_target(["b", "c"], weights=[0.5, 5])
     assert target3.shape == (2, 100)
     assert np.max(np.abs(target3)) <= 1
 
-    target4 = mtrack.get_target(["a", "c"], average=False)
+    target4 = clipgroup.get_target(["a", "c"], average=False)
     assert target4.shape == (2, 100)
     assert np.max(np.abs(target4)) <= 2
 
-    target5 = mtrack.get_target(["a", "c"], average=False, weights=[0.1, 0.5])
+    target5 = clipgroup.get_target(["a", "c"], average=False, weights=[0.1, 0.5])
     assert target5.shape == (2, 100)
     assert np.max(np.abs(target5)) <= 0.6
 
-    random_target1, t1, w1 = mtrack.get_random_target(n_tracks=2)
+    random_target1, t1, w1 = clipgroup.get_random_target(n_clips=2)
     assert random_target1.shape == (2, 100)
     assert np.max(np.abs(random_target1)) <= 1
     assert len(t1) == 2
@@ -402,7 +409,7 @@ def test_multitrack_mixing():
     assert np.all(w1 >= 0.3)
     assert np.all(w1 <= 1.0)
 
-    random_target2, t2, w2 = mtrack.get_random_target(n_tracks=5)
+    random_target2, t2, w2 = clipgroup.get_random_target(n_clips=5)
     assert random_target2.shape == (2, 100)
     assert np.max(np.abs(random_target2)) <= 1
     assert len(t2) == 3
@@ -410,7 +417,7 @@ def test_multitrack_mixing():
     assert np.all(w2 >= 0.3)
     assert np.all(w2 <= 1.0)
 
-    random_target3, t3, w3 = mtrack.get_random_target()
+    random_target3, t3, w3 = clipgroup.get_random_target()
     assert random_target3.shape == (2, 100)
     assert np.max(np.abs(random_target3)) <= 1
     assert len(t3) == 3
@@ -418,8 +425,8 @@ def test_multitrack_mixing():
     assert np.all(w3 >= 0.3)
     assert np.all(w3 <= 1.0)
 
-    random_target4, t4, w4 = mtrack.get_random_target(
-        n_tracks=2, min_weight=0.1, max_weight=0.4
+    random_target4, t4, w4 = clipgroup.get_random_target(
+        n_clips=2, min_weight=0.1, max_weight=0.4
     )
     assert random_target4.shape == (2, 100)
     assert np.max(np.abs(random_target4)) <= 1
@@ -428,7 +435,7 @@ def test_multitrack_mixing():
     assert np.all(w4 >= 0.1)
     assert np.all(w4 <= 0.4)
 
-    mix = mtrack.get_mix()
+    mix = clipgroup.get_mix()
     assert mix.shape == (2, 100)
 
 
@@ -443,10 +450,10 @@ def test_multitrack_unequal_len():
         def f(self):
             return np.random.uniform(-1, 1, (2, np.random.randint(50, 100))), 1000
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestMultiTrack1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -454,7 +461,7 @@ def test_multitrack_unequal_len():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -466,28 +473,28 @@ def test_multitrack_unequal_len():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
-    index = {"multitracks": {"ab": {"tracks": ["a", "b", "c"]}}}
-    mtrack_id = "ab"
+    index = {"clipgroups": {"ab": {"clips": ["a", "b", "c"]}}}
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = TestMultiTrack1(
-        mtrack_id, data_home, dataset_name, index, TestTrack, lambda: None
+    clipgroup = TestMultiTrack1(
+        clipgroup_id, data_home, dataset_name, index, TestTrack, lambda: None
     )
 
     with pytest.raises(ValueError):
-        mtrack.get_target(["a", "b", "c"])
+        clipgroup.get_target(["a", "b", "c"])
 
     with pytest.raises(KeyError):
-        mtrack.get_target(["d", "e"])
+        clipgroup.get_target(["d", "e"])
 
-    target1 = mtrack.get_target(["a", "b", "c"], enforce_length=False)
+    target1 = clipgroup.get_target(["a", "b", "c"], enforce_length=False)
     assert target1.shape[0] == 2
     assert np.max(np.abs(target1)) <= 1
 
-    target2 = mtrack.get_target(["a", "b", "c"], average=False, enforce_length=False)
+    target2 = clipgroup.get_target(["a", "b", "c"], average=False, enforce_length=False)
     assert target2.shape[0] == 2
     assert np.max(np.abs(target2)) <= 3
 
@@ -503,10 +510,10 @@ def test_multitrack_unequal_sr():
         def f(self):
             return np.random.uniform(-1, 1, (2, 100)), np.random.randint(10, 1000)
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestMultiTrack1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -514,7 +521,7 @@ def test_multitrack_unequal_sr():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -526,24 +533,24 @@ def test_multitrack_unequal_sr():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
-    index = {"multitracks": {"ab": {"tracks": ["a", "b", "c"]}}}
-    mtrack_id = "ab"
+    index = {"clipgroups": {"ab": {"clips": ["a", "b", "c"]}}}
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = TestMultiTrack1(
-        mtrack_id,
+    clipgroup = TestMultiTrack1(
+        clipgroup_id,
         data_home,
         dataset_name,
         index,
         TestTrack,
-        lambda: track_metadata_none,
+        lambda: clip_metadata_none,
     )
 
     with pytest.raises(ValueError):
-        mtrack.get_target(["a", "b", "c"])
+        clipgroup.get_target(["a", "b", "c"])
 
 
 def test_multitrack_mono():
@@ -558,10 +565,10 @@ def test_multitrack_mono():
         def f(self):
             return np.random.uniform(-1, 1, (100)), 1000
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestClipGroup1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -569,7 +576,7 @@ def test_multitrack_mono():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -581,22 +588,22 @@ def test_multitrack_mono():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
-    index = {"multitracks": {"ab": {"tracks": ["a", "b", "c"]}}}
-    mtrack_id = "ab"
+    index = {"clipgroups": {"ab": {"clips": ["a", "b", "c"]}}}
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = TestMultiTrack1(
-        mtrack_id, data_home, dataset_name, index, TestTrack, lambda: None
+    clipgroup = TestClipGroup1(
+        clipgroup_id, data_home, dataset_name, index, TestTrack, lambda: None
     )
 
-    target1 = mtrack.get_target(["a", "c"])
+    target1 = clipgroup.get_target(["a", "c"])
     assert target1.shape == (1, 100)
     assert np.max(np.abs(target1)) <= 1
 
-    target1 = mtrack.get_target(["a", "c"], average=False)
+    target1 = clipgroup.get_target(["a", "c"], average=False)
     assert target1.shape == (1, 100)
     assert np.max(np.abs(target1)) <= 2
 
@@ -611,10 +618,10 @@ def test_multitrack_mono():
         def f(self):
             return np.random.uniform(-1, 1, (1, 100)), 1000
 
-    class TestMultiTrack1(core.MultiTrack):
+    class TestClipGroup1(core.ClipGroup):
         def __init__(
             self,
-            mtrack_id,
+            clipgroup_id,
             data_home,
             dataset_name,
             index,
@@ -622,7 +629,7 @@ def test_multitrack_mono():
             metadata,
         ):
             super().__init__(
-                mtrack_id,
+                clipgroup_id,
                 data_home,
                 dataset_name,
                 index,
@@ -634,21 +641,21 @@ def test_multitrack_mono():
             return None
 
         @property
-        def track_audio_property(self):
+        def clip_audio_property(self):
             return "f"
 
-    index = {"multitracks": {"ab": {"tracks": ["a", "b", "c"]}}}
-    mtrack_id = "ab"
+    index = {"clipgroups": {"ab": {"clips": ["a", "b", "c"]}}}
+    clipgroup_id = "ab"
     dataset_name = "test"
     data_home = "tests/resources/mir_datasets"
-    mtrack = TestMultiTrack1(
-        mtrack_id, data_home, dataset_name, index, TestTrack, lambda: None
+    clipgroup = TestClipGroup1(
+        clipgroup_id, data_home, dataset_name, index, TestTrack, lambda: None
     )
 
-    target1 = mtrack.get_target(["a", "c"])
+    target1 = clipgroup.get_target(["a", "c"])
     assert target1.shape == (1, 100)
     assert np.max(np.abs(target1)) <= 1
 
-    target1 = mtrack.get_target(["a", "c"], average=False)
+    target1 = clipgroup.get_target(["a", "c"], average=False)
     assert target1.shape == (1, 100)
     assert np.max(np.abs(target1)) <= 2

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -433,7 +433,9 @@ def test_clipgroups():
         data_home = os.path.join(data_home_dir, dataset_name)
         dataset_specific = soundata.initialize(dataset_name, data_home=data_home)
         try:
-            clipgroup_test = dataset_specific.ClipGroup(clipgroup_id, data_home=data_home)
+            clipgroup_test = dataset_specific.ClipGroup(
+                clipgroup_id, data_home=data_home
+            )
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -69,9 +69,9 @@ def test_dataset_attributes():
         assert (
             isinstance(dataset._download_info, str) or dataset._download_info is None
         ), "{}.DOWNLOAD_INFO must be a string".format(dataset_name)
-        assert type(dataset._track_class) == type(
+        assert type(dataset._clip_class) == type(
             core.Clip
-        ), "{}.Track must be an instance of core.Track".format(dataset_name)
+        ), "{}.Track must be an instance of core.Clip".format(dataset_name)
         assert callable(dataset.download), "{}.download is not a function".format(
             dataset_name
         )
@@ -180,7 +180,7 @@ def test_validate(skip_local):
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
 
-def test_load_and_trackids():
+def test_load_and_clipids():
     for dataset_name in DATASETS:
         data_home = os.path.join("tests/resources/mir_datasets", dataset_name)
         module = importlib.import_module("soundata.datasets.{}".format(dataset_name))
@@ -193,22 +193,22 @@ def test_load_and_trackids():
         assert type(clip_ids) is list, "{}.clip_ids() should return a list".format(
             dataset_name
         )
-        trackid_len = len(clip_ids)
-        # if the dataset has tracks, test the loaders
-        if dataset._track_class is not None:
+        clipid_len = len(clip_ids)
+        # if the dataset has clips, test the loaders
+        if dataset._clip_class is not None:
 
             try:
-                choice_track = dataset.choice_track()
+                choice_clip = dataset.choice_clip()
             except:
                 assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
             assert isinstance(
-                choice_track, core.Clip
-            ), "{}.choice_track must return an instance of type core.Track".format(
+                choice_clip, core.Clip
+            ), "{}.choice_clip must return an instance of type core.Clip".format(
                 dataset_name
             )
 
             try:
-                dataset_data = dataset.load_tracks()
+                dataset_data = dataset.load_clips()
             except:
                 assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
@@ -216,13 +216,13 @@ def test_load_and_trackids():
                 dataset_data, dict
             ), "{}.load should return a dictionary".format(dataset_name)
             assert (
-                len(dataset_data.keys()) == trackid_len
+                len(dataset_data.keys()) == clipid_len
             ), "the dictionary returned {}.load() does not have the same number of elements as {}.clip_ids()".format(
                 dataset_name, dataset_name
             )
 
 
-def test_track():
+def test_clip():
     data_home_dir = "tests/resources/mir_datasets"
 
     for dataset_name in DATASETS:
@@ -231,11 +231,11 @@ def test_track():
         module = importlib.import_module("soundata.datasets.{}".format(dataset_name))
         dataset = module.Dataset(os.path.join(TEST_DATA_HOME, dataset_name))
 
-        # if the dataset doesn't have a track object, make sure it raises a value error
+        # if the dataset doesn't have a clip object, make sure it raises a value error
         # and move on to the next dataset
-        if dataset._track_class is None:
+        if dataset._clip_class is None:
             with pytest.raises(NotImplementedError):
-                dataset.clip("~faketrackid~?!")
+                dataset.clip("~fakeclipid~?!")
             continue
 
         if dataset_name in CUSTOM_TEST_TRACKS:
@@ -245,37 +245,37 @@ def test_track():
 
         # test data home specified
         try:
-            track_test = dataset.clip(clipid)
+            clip_test = dataset.clip(clipid)
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
         assert isinstance(
-            track_test, core.Clip
-        ), "{}.track must be an instance of type core.Track".format(dataset_name)
+            clip_test, core.Clip
+        ), "{}.clip must be an instance of type core.Clip".format(dataset_name)
 
         assert hasattr(
-            track_test, "to_jams"
-        ), "{}.track must have a to_jams method".format(dataset_name)
+            clip_test, "to_jams"
+        ), "{}.clip must have a to_jams method".format(dataset_name)
 
         # test calling all attributes, properties and cached properties
-        track_data = get_attributes_and_properties(track_test)
+        clip_data = get_attributes_and_properties(clip_test)
 
-        for attr in track_data["attributes"]:
-            ret = getattr(track_test, attr)
+        for attr in clip_data["attributes"]:
+            ret = getattr(clip_test, attr)
 
-        for prop in track_data["properties"]:
-            ret = getattr(track_test, prop)
+        for prop in clip_data["properties"]:
+            ret = getattr(clip_test, prop)
 
-        for cprop in track_data["cached_properties"]:
-            ret = getattr(track_test, cprop)
+        for cprop in clip_data["cached_properties"]:
+            ret = getattr(clip_test, cprop)
 
         # Validate JSON schema
         try:
-            jam = track_test.to_jams()
+            jam = clip_test.to_jams()
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
-        assert jam.validate(), "Jams validation failed for {}.track({})".format(
+        assert jam.validate(), "Jams validation failed for {}.clip({})".format(
             dataset_name, clipid
         )
 
@@ -283,20 +283,20 @@ def test_track():
         try:
             text_trap = io.StringIO()
             sys.stdout = text_trap
-            print(track_test)
+            print(clip_test)
             sys.stdout = sys.__stdout__
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
         with pytest.raises(ValueError):
-            dataset.clip("~faketrackid~?!")
+            dataset.clip("~fakeclipid~?!")
 
 
 # This tests the case where there is no data in data_home.
-# It makes sure that the track can be initialized and the
+# It makes sure that the clip can be initialized and the
 # attributes accessed, but that anything requiring data
 # files errors (all properties and cached properties).
-def test_track_placeholder_case():
+def test_clip_placeholder_case():
     data_home_dir = "not/a/real/path"
 
     for dataset_name in DATASETS:
@@ -305,7 +305,7 @@ def test_track_placeholder_case():
         module = importlib.import_module("soundata.datasets.{}".format(dataset_name))
         dataset = module.Dataset(os.path.join(data_home, dataset_name))
 
-        if dataset._track_class is None or dataset.remote_index:
+        if dataset._clip_class is None or dataset.remote_index:
             continue
 
         if dataset_name in CUSTOM_TEST_TRACKS:
@@ -314,22 +314,22 @@ def test_track_placeholder_case():
             clipid = dataset.clip_ids[0]
 
         try:
-            track_test = dataset.clip(clipid)
+            clip_test = dataset.clip(clipid)
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
-        track_data = get_attributes_and_properties(track_test)
+        clip_data = get_attributes_and_properties(clip_test)
 
-        for attr in track_data["attributes"]:
-            ret = getattr(track_test, attr)
+        for attr in clip_data["attributes"]:
+            ret = getattr(clip_test, attr)
 
-        for prop in track_data["properties"]:
+        for prop in clip_data["properties"]:
             with pytest.raises(Exception):
-                ret = getattr(track_test, prop)
+                ret = getattr(clip_test, prop)
 
-        for cprop in track_data["cached_properties"]:
+        for cprop in clip_data["cached_properties"]:
             with pytest.raises(Exception):
-                ret = getattr(track_test, cprop)
+                ret = getattr(clip_test, cprop)
 
 
 # for load_* functions which require more than one argument
@@ -374,7 +374,7 @@ def test_load_methods():
             method_name = load_method.__name__
 
             # skip default methods
-            if method_name == "load_tracks" or method_name == "load_multitracks":
+            if method_name == "load_clips" or method_name == "load_clipgroups":
                 continue
 
             # skip overrides, add to the SKIP dictionary to skip a specific load method
@@ -408,7 +408,7 @@ def test_load_methods():
 CUSTOM_TEST_MTRACKS = {}
 
 
-def test_multitracks():
+def test_clipgroups():
     data_home_dir = "tests/resources/mir_datasets"
 
     for dataset_name in DATASETS:
@@ -419,13 +419,13 @@ def test_multitracks():
         # TODO this is currently an opt-in test. Make it an opt out test
         # once #265 is addressed
         if dataset_name in CUSTOM_TEST_MTRACKS:
-            mtrack_id = CUSTOM_TEST_MTRACKS[dataset_name]
+            clipgroup_id = CUSTOM_TEST_MTRACKS[dataset_name]
         else:
-            # there are no multitracks
+            # there are no clipgroups
             continue
 
         try:
-            mtrack_default = dataset.MultiTrack(mtrack_id)
+            clipgroup_default = dataset.ClipGroup(clipgroup_id)
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
@@ -433,26 +433,26 @@ def test_multitracks():
         data_home = os.path.join(data_home_dir, dataset_name)
         dataset_specific = soundata.initialize(dataset_name, data_home=data_home)
         try:
-            mtrack_test = dataset_specific.MultiTrack(mtrack_id, data_home=data_home)
+            clipgroup_test = dataset_specific.ClipGroup(clipgroup_id, data_home=data_home)
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
         assert isinstance(
-            mtrack_test, core.MultiTrack
-        ), "{}.MultiTrack must be an instance of type core.MultiTrack".format(
+            clipgroup_test, core.ClipGroup
+        ), "{}.ClipGroup must be an instance of type core.ClipGroup".format(
             dataset_name
         )
 
         assert hasattr(
-            mtrack_test, "to_jams"
-        ), "{}.MultiTrack must have a to_jams method".format(dataset_name)
+            clipgroup_test, "to_jams"
+        ), "{}.ClipGroup must have a to_jams method".format(dataset_name)
 
         # Validate JSON schema
         try:
-            jam = mtrack_test.to_jams()
+            jam = clipgroup_test.to_jams()
         except:
             assert False, "{}: {}".format(dataset_name, sys.exc_info()[0])
 
-        assert jam.validate(), "Jams validation failed for {}.MultiTrack({})".format(
-            dataset_name, mtrack_id
+        assert jam.validate(), "Jams validation failed for {}.ClipGroup({})".format(
+            dataset_name, clipgroup_id
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,33 +12,33 @@ import pytest
 DEFAULT_DATA_HOME = os.path.join(os.getenv("HOME", "/tmp"), "mir_datasets")
 
 
-def run_track_tests(track, expected_attributes, expected_property_types):
-    track_attr = get_attributes_and_properties(track)
+def run_clip_tests(clip, expected_attributes, expected_property_types):
+    clip_attr = get_attributes_and_properties(clip)
 
-    # test track attributes
-    for attr in track_attr["attributes"]:
-        print("{}: {}".format(attr, getattr(track, attr)))
-        assert expected_attributes[attr] == getattr(track, attr)
+    # test clip attributes
+    for attr in clip_attr["attributes"]:
+        print("{}: {}".format(attr, getattr(clip, attr)))
+        assert expected_attributes[attr] == getattr(clip, attr)
 
-    # test track property types
-    for prop in track_attr["cached_properties"] + track_attr["properties"]:
-        print("{}: {}".format(prop, type(getattr(track, prop))))
+    # test clip property types
+    for prop in clip_attr["cached_properties"] + clip_attr["properties"]:
+        print("{}: {}".format(prop, type(getattr(clip, prop))))
         if prop in expected_property_types:
-            assert isinstance(getattr(track, prop), expected_property_types[prop])
+            assert isinstance(getattr(clip, prop), expected_property_types[prop])
         elif prop in expected_attributes:
-            assert expected_attributes[prop] == getattr(track, prop)
+            assert expected_attributes[prop] == getattr(clip, prop)
         else:
             assert (
                 False
             ), "{} not in expected_property_types or expected_attributes".format(prop)
 
 
-def run_multitrack_tests(mtrack):
-    tracks = getattr(mtrack, "tracks")
-    track_ids = getattr(mtrack, "track_ids")
-    assert list(tracks.keys()) == track_ids
-    for k, track in tracks.items():
-        assert getattr(track, "track_id") in track_ids
+def run_clipgroup_tests(clipgroup):
+    clips = getattr(clipgroup, "clips")
+    clip_ids = getattr(clipgroup, "clip_ids")
+    assert list(clips.keys()) == clip_ids
+    for k, clip in clips.items():
+        assert getattr(clip, "clip_id") in clip_ids
 
 
 def get_attributes_and_properties(class_instance):
@@ -105,16 +105,16 @@ def test_md5(mocker):
 @pytest.mark.parametrize(
     "test_index,expected_missing,expected_inv_checksum",
     [
-        ("test_index_valid.json", {"tracks": {}}, {"tracks": {}}),
+        ("test_index_valid.json", {"clips": {}}, {"clips": {}}),
         (
             "test_index_missing_file.json",
-            {"tracks": {"10161_chorus": ["tests/resources/10162_chorus.wav"]}},
-            {"tracks": {}},
+            {"clips": {"10161_chorus": ["tests/resources/10162_chorus.wav"]}},
+            {"clips": {}},
         ),
         (
             "test_index_invalid_checksum.json",
-            {"tracks": {}},
-            {"tracks": {"10161_chorus": ["tests/resources/10161_chorus.wav"]}},
+            {"clips": {}},
+            {"clips": {"10161_chorus": ["tests/resources/10161_chorus.wav"]}},
         ),
     ],
 )
@@ -135,14 +135,14 @@ def test_validate_index(test_index, expected_missing, expected_inv_checksum):
     "missing_files,invalid_checksums",
     [
         (
-            {"tracks": {"10161_chorus": ["tests/resources/10162_chorus.wav"]}},
-            {"tracks": {}},
+            {"clips": {"10161_chorus": ["tests/resources/10162_chorus.wav"]}},
+            {"clips": {}},
         ),
         (
-            {"tracks": {}},
-            {"tracks": {"10161_chorus": ["tests/resources/10161_chorus.wav"]}},
+            {"clips": {}},
+            {"clips": {"10161_chorus": ["tests/resources/10161_chorus.wav"]}},
         ),
-        ({"tracks": {}}, {"tracks": {}}),
+        ({"clips": {}}, {"clips": {}}),
     ],
 )
 def test_validator(mocker, mock_validate_index, missing_files, invalid_checksums):


### PR DESCRIPTION
Following discussions with @magdalenafuentes, @pseeth and @ethman, we've decided to rename MultiTrack to ClipGroup.

This PR implements this change, and also covers other places where we still needed to port tracks --> clips (e.g. in the dataset indexes).

The PR does not cover the dataset .py files, since they don't fail the tests and will be removed in the near future.