### PR TITLE
Fix download URL (for zenodo tracking)

### DIFF
--- a/soundata/datasets/urbansound8k.py
+++ b/soundata/datasets/urbansound8k.py
@@ -153,7 +153,7 @@ BIBTEX = """
 REMOTES = {
     "all": download_utils.RemoteFileMetadata(
         filename="UrbanSound8K.tar.gz",
-        url="https://zenodo.org/record/1203745/files/UrbanSound8K.tar.gz",
+        url="https://zenodo.org/record/1203745/files/UrbanSound8K.tar.gz?download=1",
         checksum="9aa69802bbf37fb986f71ec1483a196e",
         unpack_directories=["UrbanSound8K"],
     )


### PR DESCRIPTION
@magdalenafuentes tiny fix to download URL (previous one worked but setting to exactly what zenodo gives to be on the safe side in terms of download counts)