### PR TITLE
Fix attribute checking in test, minor bug in SINGA:PURA, and add directory cleanup for ESC50 download test

### DIFF
--- a/soundata/datasets/singapura.py
+++ b/soundata/datasets/singapura.py
@@ -256,7 +256,7 @@ class Clip(core.Clip):
         Returns:
             * str - location of the sensor, one of {'East 1', 'East 2', 'West 1', 'West 2'}
         """
-        return self._clip_metadata["sensor_id"]
+        return self._clip_metadata["town"]
 
     @property
     def timestamp(self) -> np.datetime64:

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -341,7 +341,7 @@ def test_unpackdir(httpserver):
             "audio/1-137-A-32.wav",
         )
     )
-    
+
     # clean up the directory after test
     shutil.rmtree(data_home)
 

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -341,6 +341,9 @@ def test_unpackdir(httpserver):
             "audio/1-137-A-32.wav",
         )
     )
+    
+    # clean up the directory after test
+    shutil.rmtree(data_home)
 
 
 def test_unzip():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,11 +23,21 @@ def run_clip_tests(clip, expected_attributes, expected_property_types):
     # test clip property types
     for prop in clip_attr["cached_properties"] + clip_attr["properties"]:
         print("{}: {}".format(prop, type(getattr(clip, prop))))
+        
+        is_tested = False
+        
         if prop in expected_property_types:
             assert isinstance(getattr(clip, prop), expected_property_types[prop])
-        elif prop in expected_attributes:
+            is_tested = True
+        
+        # Previously, this is ignored if the property is already in `expected_property_types`
+        # However, this will cause attribute value bugs to silently pass the tests.
+        # This is a workaround to prevent this from happening.
+        if prop in expected_attributes:
             assert expected_attributes[prop] == getattr(clip, prop)
-        else:
+            is_tested = True
+        
+        if not is_tested:
             assert (
                 False
             ), "{} not in expected_property_types or expected_attributes".format(prop)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -23,20 +23,20 @@ def run_clip_tests(clip, expected_attributes, expected_property_types):
     # test clip property types
     for prop in clip_attr["cached_properties"] + clip_attr["properties"]:
         print("{}: {}".format(prop, type(getattr(clip, prop))))
-        
+
         is_tested = False
-        
+
         if prop in expected_property_types:
             assert isinstance(getattr(clip, prop), expected_property_types[prop])
             is_tested = True
-        
+
         # Previously, this is ignored if the property is already in `expected_property_types`
         # However, this will cause attribute value bugs to silently pass the tests.
         # This is a workaround to prevent this from happening.
         if prop in expected_attributes:
             assert expected_attributes[prop] == getattr(clip, prop)
             is_tested = True
-        
+
         if not is_tested:
             assert (
                 False


### PR DESCRIPTION
Three main changes here:

- Fix SINGA:PURA attribute from incorrectly returning town attribute (#103)
- Fix `tests/test_utils.py` from silently ignoring attribute value checking when the types are also stated. Thanks to @pzinemanas for spotting this in #103.
- Automatically removes the `tests/resources/sound_datasets/esc50_download` folder after test has been run.