### PR TITLE
Moving spatial event as a separate class in annotations

### DIFF
--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -134,6 +134,218 @@ class Events(Annotation):
         self.cartesian_coord_unit = cartesian_coord_unit
 
 
+#: position units
+ELEVATIONS_UNITS = {
+    "degrees": "degrees",
+}
+AZIMUTHS_UNITS = {
+    "degrees": "degrees",
+}
+DISTANCES_UNITS = {
+    "meters": "meters",
+}
+
+#: Time units
+TIME_UNITS = {
+    "seconds": "seconds",
+    "milliseconds": "milliseconds",
+}
+
+#: Label units
+LABEL_UNITS = {"open": "no strict schema or units"}
+
+
+class SpatialEvents:
+    """SpatialEvents class
+    Attributes:
+        intervals (list): list of size n np.ndarrays of shape (m, 2), with intervals
+            (as floats) in TIME_UNITS in the form [start_time, end_time]
+            with positive time stamps and end_time >= start_time.
+            n is the number of sound events.
+            m is the number of sounding instances for each sound event.
+        intervals_unit (str): intervals unit, one of TIME_UNITS
+        time_step (int, float, or None): the time-step between events
+            over time in intervals_unit
+        elevations (list): list of size n with np.ndarrays with dtype int,
+            indicating the elevation of the sound event per time_step if moving
+            or a single value if static. Values between -90 and 90
+        elevations_unit (str): elevations unit, one of ELEVATIONS_UNITS
+        azimuths (list): list of size n with np.ndarrays with dtype int,
+            indicating the azimuth of the sound event per time_step if moving
+            or a single value if static. Values between -180 and 180
+        azimuths_unit (str): azimuths unit, one of AZIMUTHS_UNITS
+        distances (list): list of size n with np.ndarrays with dtype int,
+            indicating the distance of the sound event per time_step if moving
+            or a single value if static. Values must be positive or None
+        distances_unit (str): distances unit, one of DISTANCES_UNITS
+        labels (list): list of event labels (as strings)
+        labels_unit (str): labels unit, one of LABELS_UNITS
+        clip_number_indices (list): list of clip number indices (as strings)
+        confidence (np.ndarray or None): array of confidence values, float in [0, 1]
+    """
+
+    def __init__(
+        self,
+        intervals,
+        intervals_unit,
+        elevations,
+        elevations_unit,
+        azimuths,
+        azimuths_unit,
+        distances,
+        distances_unit,
+        labels,
+        labels_unit,
+        clip_number_index=None,
+        time_step=None,
+        confidence=None,
+    ):
+        # validate_array_like(intervals, list, list)
+        validate_array_like(labels, list, str)
+        validate_array_like(confidence, np.ndarray, float, none_allowed=True)
+        [
+            [
+                validate_intervals(intervals[np.newaxis, :])
+                for intervals in event_intervals
+            ]
+            for event_intervals in intervals
+        ]
+        validate_confidence(confidence)
+        validate_unit(labels_unit, LABEL_UNITS)
+        validate_unit(intervals_unit, TIME_UNITS)
+
+        self.intervals = intervals
+        self.intervals_unit = intervals_unit
+        self.labels = labels
+        self.labels_unit = labels_unit
+        self.confidence = confidence
+
+        validate_array_like(clip_number_index, list, str)
+        validate_array_like(elevations, list, list)
+        validate_array_like(azimuths, list, list)
+        validate_array_like(distances, list, list)
+        validate_lengths_equal(
+            [
+                intervals,
+                elevations,
+                azimuths,
+                distances,
+                labels,
+                clip_number_index,
+                confidence,
+            ]
+        )
+        # validate location information for each event are numpy arrays
+        [
+            [
+                [validate_array_like(subitem, np.ndarray, int) for subitem in sitem]
+                for sitem in item
+            ]
+            for item in [elevations, azimuths]
+        ]
+        [
+            [
+                validate_array_like(
+                    subitem, np.ndarray, np.array([None]).dtype, none_allowed=True
+                )
+                for subitem in item
+            ]
+            for item in distances
+        ]
+        # validate length of location information is consistent
+        # for each event
+        [
+            [validate_lengths_equal([e, a, d]) for e, a, d in zip(els, azs, dis)]
+            for els, azs, dis in zip(elevations, azimuths, distances)
+        ]
+        [
+            [
+                validate_locations(
+                    np.concatenate(
+                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
+                    )
+                )
+                for e, a, d in zip(els, azs, dis)
+            ]
+            for els, azs, dis in zip(elevations, azimuths, distances)
+        ]
+        [
+            [
+                validate_time_steps(
+                    time_step,
+                    np.concatenate(
+                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
+                    ),
+                    i,
+                )
+                for e, a, d, i in zip(els, azs, dis, ivl)
+            ]
+            for els, azs, dis, ivl in zip(elevations, azimuths, distances, intervals)
+        ]
+
+        validate_unit(elevations_unit, ELEVATIONS_UNITS)
+        validate_unit(azimuths_unit, AZIMUTHS_UNITS)
+        validate_unit(distances_unit, DISTANCES_UNITS)
+
+        self.time_step = time_step
+        self.elevations = elevations
+        self.azimuths = azimuths
+        self.distances = distances
+        self.clip_number_index = clip_number_index
+        self.elevations_unit = elevations_unit
+        self.azimuths_unit = azimuths_unit
+        self.distances_unit = distances_unit
+
+
+def validate_time_steps(time_step, locations, interval):
+    """Validate if timesteps are well-formed.
+    If locations is None, validation passes automatically
+    Args:
+        time_step (float): spacing between location steps
+        locations (np.ndarray): (n x 3) array
+        interval (np.ndarray): (n x 2) expected start and end time
+            for the locations
+    Raises:
+        ValueError: if the number of locations does not match
+            the number of time_steps that fit in the interval
+    """
+    if interval[0] > interval[1]:
+        raise ValueError("The interval has a start_time greater than the end_time")
+    elif len(locations) == 1 and interval[1] - interval[0] > 0:
+        pass  # the event is static
+    # if the object is static, validation passes
+    elif not np.isclose(len(locations) - 1, (interval[1] - interval[0]) / time_step):
+        raise ValueError(
+            "The number of locations does not fit in the interval, given the time_step"
+        )
+
+
+def validate_locations(locations):
+    """Validate if locations are well-formed.
+    If locations is None, validation passes automatically
+    Args:
+        locations (np.ndarray): (n x 3) array
+    Raises:
+        ValueError: if locations have an invalid shape or
+                have cartesian coordinate values outside the expected ranges.
+    """
+
+    # validate that locations have the correct shape
+    locations_shape = np.shape(locations)
+    if len(locations_shape) != 2 or locations_shape[1] != 3:
+        raise ValueError(
+            f"Locations should be arrays with three columns, but array has shape {locations_shape}"
+        )
+
+    # validate that values are within expected ranges
+    if (np.abs(locations[:, 0]) > 90).any():
+        raise ValueError(f"Elevation values should have magnitude less than 90")
+    if (np.abs(locations[:, 1]) > 180).any():
+        raise ValueError(f"Azimuth values should have magnitude less than 180")
+    elif (locations[:, 2] != None).any():
+        raise ValueError(f"Distance values should be nonnegative numbers")
+
+
 class MultiAnnotator(Annotation):
     """Multiple annotator class.
     This class should be used for datasets with multiple annotators (e.g. multiple annotators per clip).

--- a/soundata/annotations.py
+++ b/soundata/annotations.py
@@ -200,7 +200,7 @@ class SpatialEvents:
         time_step=None,
         confidence=None,
     ):
-        # validate_array_like(intervals, list, list)
+        validate_array_like(intervals, list, list)
         validate_array_like(labels, list, str)
         validate_array_like(confidence, np.ndarray, float, none_allowed=True)
         [

--- a/soundata/datasets/starss2022.py
+++ b/soundata/datasets/starss2022.py
@@ -137,225 +137,6 @@ LICENSE_INFO = """
 This datast is licensed under the [MIT](https://opensource.org/licenses/MIT) license
 """
 
-#: position units
-ELEVATIONS_UNITS = {
-    "degrees": "degrees",
-}
-AZIMUTHS_UNITS = {
-    "degrees": "degrees",
-}
-DISTANCES_UNITS = {
-    "meters": "meters",
-}
-
-#: Time units
-TIME_UNITS = {
-    "seconds": "seconds",
-    "milliseconds": "milliseconds",
-}
-
-#: Label units
-LABEL_UNITS = {"open": "no strict schema or units"}
-
-
-class SpatialEvents:
-    """SpatialEvents class
-    Attributes:
-        intervals (list): list of size n np.ndarrays of shape (m, 2), with intervals
-            (as floats) in TIME_UNITS in the form [start_time, end_time]
-            with positive time stamps and end_time >= start_time.
-            n is the number of sound events.
-            m is the number of sounding instances for each sound event.
-        intervals_unit (str): intervals unit, one of TIME_UNITS
-        time_step (int, float, or None): the time-step between events
-            over time in intervals_unit
-        elevations (list): list of size n with np.ndarrays with dtype int,
-            indicating the elevation of the sound event per time_step if moving
-            or a single value if static. Values between -90 and 90
-        elevations_unit (str): elevations unit, one of ELEVATIONS_UNITS
-        azimuths (list): list of size n with np.ndarrays with dtype int,
-            indicating the azimuth of the sound event per time_step if moving
-            or a single value if static. Values between -180 and 180
-        azimuths_unit (str): azimuths unit, one of AZIMUTHS_UNITS
-        distances (list): list of size n with np.ndarrays with dtype int,
-            indicating the distance of the sound event per time_step if moving
-            or a single value if static. Values must be positive or None
-        distances_unit (str): distances unit, one of DISTANCES_UNITS
-        labels (list): list of event labels (as strings)
-        labels_unit (str): labels unit, one of LABELS_UNITS
-        clip_number_indices (list): list of clip number indices (as strings)
-        confidence (np.ndarray or None): array of confidence values, float in [0, 1]
-    """
-
-    def __init__(
-        self,
-        intervals,
-        intervals_unit,
-        time_step,
-        elevations,
-        elevations_unit,
-        azimuths,
-        azimuths_unit,
-        distances,
-        distances_unit,
-        labels,
-        labels_unit,
-        clip_number_index,
-        confidence=None,
-    ):
-        annotations.validate_array_like(intervals, list, list)
-        annotations.validate_array_like(labels, list, str)
-        annotations.validate_array_like(
-            confidence, np.ndarray, float, none_allowed=True
-        )
-        [
-            [
-                annotations.validate_intervals(intervals[np.newaxis, :])
-                for intervals in event_intervals
-            ]
-            for event_intervals in intervals
-        ]
-        annotations.validate_confidence(confidence)
-        annotations.validate_unit(labels_unit, LABEL_UNITS)
-        annotations.validate_unit(intervals_unit, TIME_UNITS)
-
-        self.intervals = intervals
-        self.intervals_unit = intervals_unit
-        self.labels = labels
-        self.labels_unit = labels_unit
-        self.confidence = confidence
-
-        annotations.validate_array_like(clip_number_index, list, str)
-        annotations.validate_array_like(elevations, list, list)
-        annotations.validate_array_like(azimuths, list, list)
-        annotations.validate_array_like(distances, list, list)
-        annotations.validate_lengths_equal(
-            [
-                intervals,
-                elevations,
-                azimuths,
-                distances,
-                labels,
-                clip_number_index,
-                confidence,
-            ]
-        )
-        # validate location information for each event are numpy arrays
-        [
-            [
-                [
-                    annotations.validate_array_like(subitem, np.ndarray, int)
-                    for subitem in sitem
-                ]
-                for sitem in item
-            ]
-            for item in [elevations, azimuths]
-        ]
-        [
-            [
-                annotations.validate_array_like(
-                    subitem, np.ndarray, np.array([None]).dtype, none_allowed=True
-                )
-                for subitem in item
-            ]
-            for item in distances
-        ]
-        # validate length of location information is consistent
-        # for each event
-        [
-            [
-                annotations.validate_lengths_equal([e, a, d])
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_locations(
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    )
-                )
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_time_steps(
-                    time_step,
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    ),
-                    i,
-                )
-                for e, a, d, i in zip(els, azs, dis, ivl)
-            ]
-            for els, azs, dis, ivl in zip(elevations, azimuths, distances, intervals)
-        ]
-
-        annotations.validate_unit(elevations_unit, ELEVATIONS_UNITS)
-        annotations.validate_unit(azimuths_unit, AZIMUTHS_UNITS)
-        annotations.validate_unit(distances_unit, DISTANCES_UNITS)
-
-        self.time_step = time_step
-        self.elevations = elevations
-        self.azimuths = azimuths
-        self.distances = distances
-        self.clip_number_index = clip_number_index
-        self.elevations_unit = elevations_unit
-        self.azimuths_unit = azimuths_unit
-        self.distances_unit = distances_unit
-
-
-def validate_time_steps(time_step, locations, interval):
-    """Validate if STARSS 2022 timesteps are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        time_step (float): spacing between location steps
-        locations (np.ndarray): (n x 3) array
-        interval (np.ndarray): (n x 2) expected start and end time
-            for the locations
-    Raises:
-        ValueError: if the number of locations does not match
-            the number of time_steps that fit in the interval
-    """
-    if interval[0] > interval[1]:
-        raise ValueError("The interval has a start_time greater than the end_time")
-    elif len(locations) == 1 and interval[1] - interval[0] > 0:
-        pass  # the event is static
-    # if the object is static, validation passes
-    elif not np.isclose(len(locations) - 1, (interval[1] - interval[0]) / time_step):
-        raise ValueError(
-            "The number of locations does not fit in the interval, given the time_step"
-        )
-
-
-def validate_locations(locations):
-    """Validate if STARSS 2022 locations are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        locations (np.ndarray): (n x 3) array
-    Raises:
-        ValueError: if locations have an invalid shape or
-                have cartesian coordinate values outside the expected ranges.
-    """
-
-    # validate that locations have the correct shape
-    locations_shape = np.shape(locations)
-    if len(locations_shape) != 2 or locations_shape[1] != 3:
-        raise ValueError(
-            f"Locations should be arrays with three columns, but array has shape {locations_shape}"
-        )
-
-    # validate that values are within expected ranges
-    if (np.abs(locations[:, 0]) > 90).any():
-        raise ValueError(f"Elevation values should have magnitude less than 90")
-    if (np.abs(locations[:, 1]) > 180).any():
-        raise ValueError(f"Azimuth values should have magnitude less than 180")
-    elif (locations[:, 2] != None).any():
-        raise ValueError(f"Distance values should be nonnegative numbers")
-
 
 class Clip(core.Clip):
     """STARSS 2022 Clip class
@@ -396,7 +177,7 @@ class Clip(core.Clip):
         return load_audio(self.audio_path)
 
     @core.cached_property
-    def spatial_events(self) -> Optional[SpatialEvents]:
+    def spatial_events(self) -> Optional[annotations.SpatialEvents]:
         """The clip's event annotations
         Returns:
             * SpatialEvents with attributes
@@ -448,7 +229,7 @@ def load_audio(fhandle: BinaryIO, sr=24000) -> Tuple[np.ndarray, float]:
 
 
 @io.coerce_to_string_io
-def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
+def load_spatialevents(fhandle: TextIO, dt=0.1) -> annotations.SpatialEvents:
     """Load a STARSS 2022 annotation file
     Args:
         fhandle (str or file-like): File-like object or path to
@@ -581,10 +362,9 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
     ) = _process_raw_events(raw_events, dt)
     confidence = np.array([1.0] * len(labels))
 
-    events_data = SpatialEvents(
+    events_data = annotations.SpatialEvents(
         intervals,
         "seconds",
-        dt,
         elevations,
         "degrees",
         azimuths,
@@ -594,6 +374,7 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
         labels,
         "open",
         clip_number_indices,
+        dt,
         confidence,
     )
 

--- a/soundata/datasets/tau2019sse.py
+++ b/soundata/datasets/tau2019sse.py
@@ -128,7 +128,7 @@ REMOTES = {
 LICENSE_INFO = "Copyright (c) 2019 Tampere University and its licensors All rights reserved. Permission is hereby granted, without written agreement and without license or royalty fees, to use and copy the TAU Spatial Sound Events 2019 - Ambisonic and Microphone Array described in this document and composed of audio and metadata. This grant is only for experimental and non-commercial purposes, provided that the copyright notice in its entirety appear in all copies of this Work, and the original source of this Work, (Audio Research Group at Tampere University), is acknowledged in any publication that reports research using this Work. Any commercial use of the Work or any part thereof is strictly prohibited. Commercial use include, but is not limited to: selling or reproducing the Work, selling or distributing the results or content achieved by use of the Work providing services by using the Work. IN NO EVENT SHALL TAMPERE UNIVERSITY OR ITS LICENSORS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE USE OF THIS WORK AND ITS DOCUMENTATION, EVEN IF TAMPERE UNIVERSITY OR ITS LICENSORS HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. TAMPERE UNIVERSITY AND ALL ITS LICENSORS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE WORK PROVIDED HEREUNDER IS ON AN AS IS BASIS, AND THE TAMPERE UNIVERSITY HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS."
 
 
-class SpatialEvents(annotations.Events):
+class TAU2019_SpatialEvents(annotations.SpatialEvents):
     """TAU SSE 2019 Spatial Events
 
     Attributes:
@@ -157,7 +157,21 @@ class SpatialEvents(annotations.Events):
         labels_unit,
         confidence=None,
     ):
-        super().__init__(intervals, intervals_unit, labels, labels_unit, confidence)
+        super().__init__(
+            None,
+            intervals_unit,
+            None,
+            elevations_unit,
+            None,
+            azimuths_unit,
+            None,
+            distances_unit,
+            labels,
+            labels_unit,
+            clip_number_index=None,
+            time_step=None,
+            confidence=None,
+        )
 
         annotations.validate_array_like(elevations, np.ndarray, float)
         annotations.validate_array_like(azimuths, np.ndarray, float)
@@ -175,10 +189,7 @@ class SpatialEvents(annotations.Events):
                 axis=1,
             )
         )
-        annotations.validate_unit(elevations_unit, ELEVATIONS_UNITS)
-        annotations.validate_unit(azimuths_unit, AZIMUTHS_UNITS)
-        annotations.validate_unit(distances_unit, DISTANCES_UNITS)
-
+        self.intervals = intervals
         self.elevations = elevations
         self.azimuths = azimuths
         self.distances = distances
@@ -235,7 +246,7 @@ class Clip(core.Clip):
         return load_audio(self.audio_path)
 
     @core.cached_property
-    def spatial_events(self) -> Optional[SpatialEvents]:
+    def spatial_events(self) -> Optional[TAU2019_SpatialEvents]:
         """The clip's spatial events
 
         Returns:
@@ -284,7 +295,7 @@ def load_audio(fhandle: BinaryIO, sr=None) -> Tuple[np.ndarray, float]:
 
 
 @io.coerce_to_string_io
-def load_spatialevents(fhandle: TextIO) -> SpatialEvents:
+def load_spatialevents(fhandle: TextIO) -> TAU2019_SpatialEvents:
     """Load an TAU SSE 2019 annotation file
     Args:
         fhandle (str or file-like): File-like object or path to the sound events annotation file
@@ -310,7 +321,7 @@ def load_spatialevents(fhandle: TextIO) -> SpatialEvents:
         distances.append(float(line[5]))
         confidence.append(1.0)
 
-    events_data = SpatialEvents(
+    events_data = TAU2019_SpatialEvents(
         np.array(times),
         "seconds",
         np.array(elevations),

--- a/soundata/datasets/tau2020sse_nigens.py
+++ b/soundata/datasets/tau2020sse_nigens.py
@@ -132,226 +132,6 @@ LICENSE_INFO = """
 Creative Commons Attribution Non Commercial 4.0 International
 """
 
-#: position units
-ELEVATIONS_UNITS = {
-    "degrees": "degrees",
-}
-AZIMUTHS_UNITS = {
-    "degrees": "degrees",
-}
-DISTANCES_UNITS = {
-    "meters": "meters",
-}
-
-#: Time units
-TIME_UNITS = {
-    "seconds": "seconds",
-    "milliseconds": "milliseconds",
-}
-
-#: Label units
-LABEL_UNITS = {"open": "no strict schema or units"}
-
-
-class SpatialEvents:
-    """SpatialEvents class
-
-    Attributes:
-        intervals (list): list of size n np.ndarrays of shape (m, 2), with intervals
-            (as floats) in TIME_UNITS in the form [start_time, end_time]
-            with positive time stamps and end_time >= start_time.
-            n is the number of sound events.
-            m is the number of sounding instances for each sound event.
-        intervals_unit (str): intervals unit, one of TIME_UNITS
-        time_step (int, float, or None): the time-step between events
-            over time in intervals_unit
-        elevations (list): list of size n with np.ndarrays with dtype int,
-            indicating the elevation of the sound event per time_step if moving
-            or a single value if static. Values between -90 and 90
-        elevations_unit (str): elevations unit, one of ELEVATIONS_UNITS
-        azimuths (list): list of size n with np.ndarrays with dtype int,
-            indicating the azimuth of the sound event per time_step if moving
-            or a single value if static. Values between -180 and 180
-        azimuths_unit (str): azimuths unit, one of AZIMUTHS_UNITS
-        distances (list): list of size n with np.ndarrays with dtype int,
-            indicating the distance of the sound event per time_step if moving
-            or a single value if static. Values must be positive or None
-        distances_unit (str): distances unit, one of DISTANCES_UNITS
-        labels (list): list of event labels (as strings)
-        labels_unit (str): labels unit, one of LABELS_UNITS
-        clip_number_indices (list): list of clip number indices (as strings)
-        confidence (np.ndarray or None): array of confidence values, float in [0, 1]
-    """
-
-    def __init__(
-        self,
-        intervals,
-        intervals_unit,
-        time_step,
-        elevations,
-        elevations_unit,
-        azimuths,
-        azimuths_unit,
-        distances,
-        distances_unit,
-        labels,
-        labels_unit,
-        clip_number_index,
-        confidence=None,
-    ):
-        annotations.validate_array_like(intervals, list, list)
-        annotations.validate_array_like(labels, list, str)
-        annotations.validate_array_like(
-            confidence, np.ndarray, float, none_allowed=True
-        )
-        [
-            [
-                annotations.validate_intervals(intervals[np.newaxis, :])
-                for intervals in event_intervals
-            ]
-            for event_intervals in intervals
-        ]
-        annotations.validate_confidence(confidence)
-        annotations.validate_unit(labels_unit, LABEL_UNITS)
-        annotations.validate_unit(intervals_unit, TIME_UNITS)
-
-        self.intervals = intervals
-        self.intervals_unit = intervals_unit
-        self.labels = labels
-        self.labels_unit = labels_unit
-        self.confidence = confidence
-
-        annotations.validate_array_like(clip_number_index, list, str)
-        annotations.validate_array_like(elevations, list, list)
-        annotations.validate_array_like(azimuths, list, list)
-        annotations.validate_array_like(distances, list, list)
-        annotations.validate_lengths_equal(
-            [
-                intervals,
-                elevations,
-                azimuths,
-                distances,
-                labels,
-                clip_number_index,
-                confidence,
-            ]
-        )
-        # validate location information for each event are numpy arrays
-        [
-            [
-                [
-                    annotations.validate_array_like(subitem, np.ndarray, int)
-                    for subitem in sitem
-                ]
-                for sitem in item
-            ]
-            for item in [elevations, azimuths]
-        ]
-        [
-            [
-                annotations.validate_array_like(
-                    subitem, np.ndarray, np.array([None]).dtype, none_allowed=True
-                )
-                for subitem in item
-            ]
-            for item in distances
-        ]
-        # validate length of location information is consistent
-        # for each event
-        [
-            [
-                annotations.validate_lengths_equal([e, a, d])
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_locations(
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    )
-                )
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_time_steps(
-                    time_step,
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    ),
-                    i,
-                )
-                for e, a, d, i in zip(els, azs, dis, ivl)
-            ]
-            for els, azs, dis, ivl in zip(elevations, azimuths, distances, intervals)
-        ]
-
-        annotations.validate_unit(elevations_unit, ELEVATIONS_UNITS)
-        annotations.validate_unit(azimuths_unit, AZIMUTHS_UNITS)
-        annotations.validate_unit(distances_unit, DISTANCES_UNITS)
-
-        self.time_step = time_step
-        self.elevations = elevations
-        self.azimuths = azimuths
-        self.distances = distances
-        self.clip_number_index = clip_number_index
-        self.elevations_unit = elevations_unit
-        self.azimuths_unit = azimuths_unit
-        self.distances_unit = distances_unit
-
-
-def validate_time_steps(time_step, locations, interval):
-    """Validate if TAU NIGENS SSE 2020 timesteps are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        time_step (float): spacing between location steps
-        locations (np.ndarray): (n x 3) array
-        interval (np.ndarray): (n x 2) expected start and end time
-            for the locations
-    Raises:
-        ValueError: if the number of locations does not match
-            the number of time_steps that fit in the interval
-    """
-    if interval[0] > interval[1]:
-        raise ValueError("The interval has a start_time greater than the end_time")
-    elif len(locations) == 1 and interval[1] - interval[0] > 0:
-        pass  # the event is static
-    # if the object is static, validation passes
-    elif not np.isclose(len(locations) - 1, (interval[1] - interval[0]) / time_step):
-        raise ValueError(
-            "The number of locations does not fit in the interval, given the time_step"
-        )
-
-
-def validate_locations(locations):
-    """Validate if TAU NIGENS SSE 2020 locations are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        locations (np.ndarray): (n x 3) array
-    Raises:
-        ValueError: if locations have an invalid shape or
-                have cartesian coordinate values outside the expected ranges.
-    """
-
-    # validate that locations have the correct shape
-    locations_shape = np.shape(locations)
-    if len(locations_shape) != 2 or locations_shape[1] != 3:
-        raise ValueError(
-            f"Locations should be arrays with three columns, but array has shape {locations_shape}"
-        )
-
-    # validate that values are within expected ranges
-    if (np.abs(locations[:, 0]) > 90).any():
-        raise ValueError(f"Elevation values should have magnitude less than 90")
-    if (np.abs(locations[:, 1]) > 180).any():
-        raise ValueError(f"Azimuth values should have magnitude less than 180")
-    elif (locations[:, 2] != None).any():
-        raise ValueError(f"Distance values should be nonnegative numbers")
-
 
 class Clip(core.Clip):
     """TAU NIGENS SSE 2020 Clip class
@@ -387,7 +167,7 @@ class Clip(core.Clip):
         return load_audio(self.audio_path)
 
     @core.cached_property
-    def spatial_events(self) -> Optional[SpatialEvents]:
+    def spatial_events(self) -> Optional[annotations.SpatialEvents]:
         """The clip's event annotations
 
         Returns:
@@ -440,7 +220,7 @@ def load_audio(fhandle: BinaryIO, sr=24000) -> Tuple[np.ndarray, float]:
 
 
 @io.coerce_to_string_io
-def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
+def load_spatialevents(fhandle: TextIO, dt=0.1) -> annotations.SpatialEvents:
     """Load an TAU NIGENS SSE 2020 annotation file
     Args:
         fhandle (str or file-like): File-like object or path to
@@ -573,10 +353,9 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
     ) = _process_raw_events(raw_events, dt)
     confidence = np.array([1.0] * len(labels))
 
-    events_data = SpatialEvents(
+    events_data = annotations.SpatialEvents(
         intervals,
         "seconds",
-        dt,
         elevations,
         "degrees",
         azimuths,
@@ -586,6 +365,7 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
         labels,
         "open",
         clip_number_indices,
+        dt,
         confidence,
     )
 

--- a/soundata/datasets/tau2021sse_nigens.py
+++ b/soundata/datasets/tau2021sse_nigens.py
@@ -140,225 +140,6 @@ LICENSE_INFO = """
 Creative Commons Attribution Non Commercial 4.0 International
 """
 
-#: position units
-ELEVATIONS_UNITS = {
-    "degrees": "degrees",
-}
-AZIMUTHS_UNITS = {
-    "degrees": "degrees",
-}
-DISTANCES_UNITS = {
-    "meters": "meters",
-}
-
-#: Time units
-TIME_UNITS = {
-    "seconds": "seconds",
-    "milliseconds": "milliseconds",
-}
-
-#: Label units
-LABEL_UNITS = {"open": "no strict schema or units"}
-
-
-class SpatialEvents:
-    """SpatialEvents class
-    Attributes:
-        intervals (list): list of size n np.ndarrays of shape (m, 2), with intervals
-            (as floats) in TIME_UNITS in the form [start_time, end_time]
-            with positive time stamps and end_time >= start_time.
-            n is the number of sound events.
-            m is the number of sounding instances for each sound event.
-        intervals_unit (str): intervals unit, one of TIME_UNITS
-        time_step (int, float, or None): the time-step between events
-            over time in intervals_unit
-        elevations (list): list of size n with np.ndarrays with dtype int,
-            indicating the elevation of the sound event per time_step if moving
-            or a single value if static. Values between -90 and 90
-        elevations_unit (str): elevations unit, one of ELEVATIONS_UNITS
-        azimuths (list): list of size n with np.ndarrays with dtype int,
-            indicating the azimuth of the sound event per time_step if moving
-            or a single value if static. Values between -180 and 180
-        azimuths_unit (str): azimuths unit, one of AZIMUTHS_UNITS
-        distances (list): list of size n with np.ndarrays with dtype int,
-            indicating the distance of the sound event per time_step if moving
-            or a single value if static. Values must be positive or None
-        distances_unit (str): distances unit, one of DISTANCES_UNITS
-        labels (list): list of event labels (as strings)
-        labels_unit (str): labels unit, one of LABELS_UNITS
-        clip_number_indices (list): list of clip number indices (as strings)
-        confidence (np.ndarray or None): array of confidence values, float in [0, 1]
-    """
-
-    def __init__(
-        self,
-        intervals,
-        intervals_unit,
-        time_step,
-        elevations,
-        elevations_unit,
-        azimuths,
-        azimuths_unit,
-        distances,
-        distances_unit,
-        labels,
-        labels_unit,
-        clip_number_index,
-        confidence=None,
-    ):
-        annotations.validate_array_like(intervals, list, list)
-        annotations.validate_array_like(labels, list, str)
-        annotations.validate_array_like(
-            confidence, np.ndarray, float, none_allowed=True
-        )
-        [
-            [
-                annotations.validate_intervals(intervals[np.newaxis, :])
-                for intervals in event_intervals
-            ]
-            for event_intervals in intervals
-        ]
-        annotations.validate_confidence(confidence)
-        annotations.validate_unit(labels_unit, LABEL_UNITS)
-        annotations.validate_unit(intervals_unit, TIME_UNITS)
-
-        self.intervals = intervals
-        self.intervals_unit = intervals_unit
-        self.labels = labels
-        self.labels_unit = labels_unit
-        self.confidence = confidence
-
-        annotations.validate_array_like(clip_number_index, list, str)
-        annotations.validate_array_like(elevations, list, list)
-        annotations.validate_array_like(azimuths, list, list)
-        annotations.validate_array_like(distances, list, list)
-        annotations.validate_lengths_equal(
-            [
-                intervals,
-                elevations,
-                azimuths,
-                distances,
-                labels,
-                clip_number_index,
-                confidence,
-            ]
-        )
-        # validate location information for each event are numpy arrays
-        [
-            [
-                [
-                    annotations.validate_array_like(subitem, np.ndarray, int)
-                    for subitem in sitem
-                ]
-                for sitem in item
-            ]
-            for item in [elevations, azimuths]
-        ]
-        [
-            [
-                annotations.validate_array_like(
-                    subitem, np.ndarray, np.array([None]).dtype, none_allowed=True
-                )
-                for subitem in item
-            ]
-            for item in distances
-        ]
-        # validate length of location information is consistent
-        # for each event
-        [
-            [
-                annotations.validate_lengths_equal([e, a, d])
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_locations(
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    )
-                )
-                for e, a, d in zip(els, azs, dis)
-            ]
-            for els, azs, dis in zip(elevations, azimuths, distances)
-        ]
-        [
-            [
-                validate_time_steps(
-                    time_step,
-                    np.concatenate(
-                        [e[:, np.newaxis], a[:, np.newaxis], d[:, np.newaxis]], axis=1
-                    ),
-                    i,
-                )
-                for e, a, d, i in zip(els, azs, dis, ivl)
-            ]
-            for els, azs, dis, ivl in zip(elevations, azimuths, distances, intervals)
-        ]
-
-        annotations.validate_unit(elevations_unit, ELEVATIONS_UNITS)
-        annotations.validate_unit(azimuths_unit, AZIMUTHS_UNITS)
-        annotations.validate_unit(distances_unit, DISTANCES_UNITS)
-
-        self.time_step = time_step
-        self.elevations = elevations
-        self.azimuths = azimuths
-        self.distances = distances
-        self.clip_number_index = clip_number_index
-        self.elevations_unit = elevations_unit
-        self.azimuths_unit = azimuths_unit
-        self.distances_unit = distances_unit
-
-
-def validate_time_steps(time_step, locations, interval):
-    """Validate if TAU NIGENS SSE 2021 timesteps are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        time_step (float): spacing between location steps
-        locations (np.ndarray): (n x 3) array
-        interval (np.ndarray): (n x 2) expected start and end time
-            for the locations
-    Raises:
-        ValueError: if the number of locations does not match
-            the number of time_steps that fit in the interval
-    """
-    if interval[0] > interval[1]:
-        raise ValueError("The interval has a start_time greater than the end_time")
-    elif len(locations) == 1 and interval[1] - interval[0] > 0:
-        pass  # the event is static
-    # if the object is static, validation passes
-    elif not np.isclose(len(locations) - 1, (interval[1] - interval[0]) / time_step):
-        raise ValueError(
-            "The number of locations does not fit in the interval, given the time_step"
-        )
-
-
-def validate_locations(locations):
-    """Validate if TAU NIGENS SSE 2021 locations are well-formed.
-    If locations is None, validation passes automatically
-    Args:
-        locations (np.ndarray): (n x 3) array
-    Raises:
-        ValueError: if locations have an invalid shape or
-                have cartesian coordinate values outside the expected ranges.
-    """
-
-    # validate that locations have the correct shape
-    locations_shape = np.shape(locations)
-    if len(locations_shape) != 2 or locations_shape[1] != 3:
-        raise ValueError(
-            f"Locations should be arrays with three columns, but array has shape {locations_shape}"
-        )
-
-    # validate that values are within expected ranges
-    if (np.abs(locations[:, 0]) > 90).any():
-        raise ValueError(f"Elevation values should have magnitude less than 90")
-    if (np.abs(locations[:, 1]) > 180).any():
-        raise ValueError(f"Azimuth values should have magnitude less than 180")
-    elif (locations[:, 2] != None).any():
-        raise ValueError(f"Distance values should be nonnegative numbers")
-
 
 class Clip(core.Clip):
     """TAU NIGENS SSE 2021 Clip class
@@ -396,7 +177,7 @@ class Clip(core.Clip):
         return load_audio(self.audio_path)
 
     @core.cached_property
-    def spatial_events(self) -> Optional[SpatialEvents]:
+    def spatial_events(self) -> Optional[annotations.SpatialEvents]:
         """The clip's event annotations
         Returns:
             * SpatialEvents with attributes
@@ -448,7 +229,7 @@ def load_audio(fhandle: BinaryIO, sr=24000) -> Tuple[np.ndarray, float]:
 
 
 @io.coerce_to_string_io
-def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
+def load_spatialevents(fhandle: TextIO, dt=0.1) -> annotations.SpatialEvents:
     """Load an TAU NIGENS SSE 2021 annotation file
     Args:
         fhandle (str or file-like): File-like object or path to
@@ -581,10 +362,9 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
     ) = _process_raw_events(raw_events, dt)
     confidence = np.array([1.0] * len(labels))
 
-    events_data = SpatialEvents(
+    events_data = annotations.SpatialEvents(
         intervals,
         "seconds",
-        dt,
         elevations,
         "degrees",
         azimuths,
@@ -594,6 +374,7 @@ def load_spatialevents(fhandle: TextIO, dt=0.1) -> SpatialEvents:
         labels,
         "open",
         clip_number_indices,
+        dt,
         confidence,
     )
 

--- a/tests/datasets/test_starss2022.py
+++ b/tests/datasets/test_starss2022.py
@@ -32,7 +32,7 @@ def test_clip():
 
     expected_property_types = {
         "audio": tuple,
-        "spatial_events": starss2022.SpatialEvents,
+        "spatial_events": annotations.SpatialEvents,
     }
 
     run_clip_tests(clip, expected_attributes, expected_property_types)
@@ -54,7 +54,7 @@ def test_load_SpatialEvents():
     dataset = starss2022.Dataset(TEST_DATA_HOME)
     clip = dataset.clip("foa_dev/dev-train-sony/fold3_room21_mix001")
     annotations_path = clip.csv_path
-    annotations = starss2022.load_spatialevents(annotations_path)
+    starss_annotations = starss2022.load_spatialevents(annotations_path)
 
     confidence = [1.0] * 4
     intervals = [
@@ -86,43 +86,43 @@ def test_load_SpatialEvents():
 
     labels = ["1", "1", "4", "4"]
     clip_number_indices = ["1", "2", "2", "1"]
-    assert np.allclose(annotations.time_step, 0.1)
-    assert np.allclose(confidence, annotations.confidence)
+    assert np.allclose(starss_annotations.time_step, 0.1)
+    assert np.allclose(confidence, starss_annotations.confidence)
     for pair in [
-        zip(elevations, annotations.elevations),
-        zip(azimuths, annotations.azimuths),
+        zip(elevations, starss_annotations.elevations),
+        zip(azimuths, starss_annotations.azimuths),
     ]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 assert np.allclose(test_data, data)
-    for pair in [zip(distances, annotations.distances)]:
+    for pair in [zip(distances, starss_annotations.distances)]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 test_data == data
-    for test_label, label in zip(labels, annotations.labels):
+    for test_label, label in zip(labels, starss_annotations.labels):
         assert test_label == label
     for test_clip_index, clip_index in zip(
-        clip_number_indices, annotations.clip_number_index
+        clip_number_indices, starss_annotations.clip_number_index
     ):
         assert test_clip_index == clip_index
     with pytest.raises(ValueError):
-        starss2022.validate_time_steps(0.1, np.array([[4, 5, 7]]), [1, 0])
+        annotations.validate_time_steps(0.1, np.array([[4, 5, 7]]), [1, 0])
     with pytest.raises(ValueError):
-        starss2022.validate_time_steps(
+        annotations.validate_time_steps(
             0.1, np.array([[4, 5, 7], [1, 2, 3]]), [0.0, 0.2]
         )
     with pytest.raises(ValueError):
         # locations are not 3D
-        starss2022.validate_locations(np.array([[4, 5], [2, 3]]))
+        annotations.validate_locations(np.array([[4, 5], [2, 3]]))
     with pytest.raises(ValueError):
         # distance is not None
-        starss2022.validate_locations(np.array([[90, 5, None], [2, 3, 4]]))
+        annotations.validate_locations(np.array([[90, 5, None], [2, 3, 4]]))
     with pytest.raises(ValueError):
         # elevation is greater than 90
-        starss2022.validate_locations(np.array([[91, 5, None], [2, 3, None]]))
+        annotations.validate_locations(np.array([[91, 5, None], [2, 3, None]]))
     with pytest.raises(ValueError):
         # elevation is greater than 181
-        starss2022.validate_locations(np.array([[90, 181, None], [2, 3, None]]))
+        annotations.validate_locations(np.array([[90, 181, None], [2, 3, None]]))
 
 
 def test_to_jams():

--- a/tests/datasets/test_tau2019sse.py
+++ b/tests/datasets/test_tau2019sse.py
@@ -32,7 +32,7 @@ def test_clip():
 
     expected_property_types = {
         "audio": tuple,
-        "spatial_events": tau2019sse.SpatialEvents,
+        "spatial_events": tau2019sse.TAU2019_SpatialEvents,
     }
 
     run_clip_tests(clip, expected_attributes, expected_property_types)

--- a/tests/datasets/test_tau2020sse_nigens.py
+++ b/tests/datasets/test_tau2020sse_nigens.py
@@ -32,7 +32,7 @@ def test_clip():
 
     expected_property_types = {
         "audio": tuple,
-        "spatial_events": tau2020sse_nigens.SpatialEvents,
+        "spatial_events": annotations.SpatialEvents,
     }
 
     run_clip_tests(clip, expected_attributes, expected_property_types)
@@ -54,7 +54,7 @@ def test_load_SpatialEvents():
     dataset = tau2020sse_nigens.Dataset(TEST_DATA_HOME)
     clip = dataset.clip("foa_dev/fold1_room1_mix001_ov1")
     annotations_path = clip.csv_path
-    annotations = tau2020sse_nigens.load_spatialevents(annotations_path)
+    tau2020_annotations = tau2020sse_nigens.load_spatialevents(annotations_path)
 
     confidence = [1.0] * 6
     intervals = [
@@ -98,43 +98,43 @@ def test_load_SpatialEvents():
 
     labels = ["1", "2", "4", "4", "5", "6"]
     clip_number_indices = ["0", "0", "0", "1", "0", "0"]
-    assert np.allclose(annotations.time_step, 0.1)
-    assert np.allclose(confidence, annotations.confidence)
+    assert np.allclose(tau2020_annotations.time_step, 0.1)
+    assert np.allclose(confidence, tau2020_annotations.confidence)
     for pair in [
-        zip(elevations, annotations.elevations),
-        zip(azimuths, annotations.azimuths),
+        zip(elevations, tau2020_annotations.elevations),
+        zip(azimuths, tau2020_annotations.azimuths),
     ]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 assert np.allclose(test_data, data)
-    for pair in [zip(distances, annotations.distances)]:
+    for pair in [zip(distances, tau2020_annotations.distances)]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 test_data == data
-    for test_label, label in zip(labels, annotations.labels):
+    for test_label, label in zip(labels, tau2020_annotations.labels):
         assert test_label == label
     for test_clip_index, clip_index in zip(
-        clip_number_indices, annotations.clip_number_index
+        clip_number_indices, tau2020_annotations.clip_number_index
     ):
         assert test_clip_index == clip_index
     with pytest.raises(ValueError):
-        tau2020sse_nigens.validate_time_steps(0.1, [4, 5, 7], [2, 1])
+        annotations.validate_time_steps(0.1, [4, 5, 7], [2, 1])
     with pytest.raises(ValueError):
-        tau2020sse_nigens.validate_time_steps(
+        annotations.validate_time_steps(
             0.1, np.array([[4, 5, 7], [1, 2, 3]]), [0.0, 0.2]
         )
     with pytest.raises(ValueError):
         # locations are not 3D
-        tau2020sse_nigens.validate_locations(np.array([[4, 5], [2, 3]]))
+        annotations.validate_locations(np.array([[4, 5], [2, 3]]))
     with pytest.raises(ValueError):
         # distance is not None
-        tau2020sse_nigens.validate_locations(np.array([[90, 5, None], [2, 3, 4]]))
+        annotations.validate_locations(np.array([[90, 5, None], [2, 3, 4]]))
     with pytest.raises(ValueError):
         # elevation is greater than 90
-        tau2020sse_nigens.validate_locations(np.array([[91, 5, None], [2, 3, None]]))
+        annotations.validate_locations(np.array([[91, 5, None], [2, 3, None]]))
     with pytest.raises(ValueError):
         # elevation is greater than 181
-        tau2020sse_nigens.validate_locations(np.array([[90, 181, None], [2, 3, None]]))
+        annotations.validate_locations(np.array([[90, 181, None], [2, 3, None]]))
 
 
 def test_to_jams():

--- a/tests/datasets/test_tau2021sse_nigens.py
+++ b/tests/datasets/test_tau2021sse_nigens.py
@@ -32,7 +32,7 @@ def test_clip():
 
     expected_property_types = {
         "audio": tuple,
-        "spatial_events": tau2021sse_nigens.SpatialEvents,
+        "spatial_events": annotations.SpatialEvents,
     }
 
     run_clip_tests(clip, expected_attributes, expected_property_types)
@@ -54,7 +54,7 @@ def test_load_SpatialEvents():
     dataset = tau2021sse_nigens.Dataset(TEST_DATA_HOME)
     clip = dataset.clip("foa_dev/dev-train/fold1_room1_mix001")
     annotations_path = clip.csv_path
-    annotations = tau2021sse_nigens.load_spatialevents(annotations_path)
+    tau2021_annotations = tau2021sse_nigens.load_spatialevents(annotations_path)
 
     confidence = [1.0] * 6
     intervals = [
@@ -98,49 +98,49 @@ def test_load_SpatialEvents():
 
     labels = ["1", "2", "4", "4", "5", "6"]
     clip_number_indices = ["0", "0", "0", "1", "0", "0"]
-    assert np.allclose(annotations.time_step, 0.1)
-    assert np.allclose(confidence, annotations.confidence)
+    assert np.allclose(tau2021_annotations.time_step, 0.1)
+    assert np.allclose(confidence, tau2021_annotations.confidence)
     for pair in [
-        zip(elevations, annotations.elevations),
-        zip(azimuths, annotations.azimuths),
+        zip(elevations, tau2021_annotations.elevations),
+        zip(azimuths, tau2021_annotations.azimuths),
     ]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 assert np.allclose(test_data, data)
-    for pair in [zip(distances, annotations.distances)]:
+    for pair in [zip(distances, tau2021_annotations.distances)]:
         for event_test_data, event_data in pair:
             for test_data, data in zip(event_test_data, event_data):
                 test_data == data
-    for test_label, label in zip(labels, annotations.labels):
+    for test_label, label in zip(labels, tau2021_annotations.labels):
         assert test_label == label
     for test_clip_index, clip_index in zip(
-        clip_number_indices, annotations.clip_number_index
+        clip_number_indices, tau2021_annotations.clip_number_index
     ):
         assert test_clip_index == clip_index
     with pytest.raises(ValueError):
-        tau2021sse_nigens.validate_time_steps(
+        annotations.validate_time_steps(
             0.1, np.array([[4, 5, 7]], dtype=object), [1, 0]
         )
     with pytest.raises(ValueError):
-        tau2021sse_nigens.validate_time_steps(
+        annotations.validate_time_steps(
             0.1, np.array([[4, 5, 7], [1, 2, 3]]), [0.0, 0.2]
         )
     with pytest.raises(ValueError):
         # locations are not 3D
-        tau2021sse_nigens.validate_locations(np.array([[4, 5], [2, 3]], dtype=object))
+        annotations.validate_locations(np.array([[4, 5], [2, 3]], dtype=object))
     with pytest.raises(ValueError):
         # distance is not None
-        tau2021sse_nigens.validate_locations(
+        annotations.validate_locations(
             np.array([[90, 5, None], [2, 3, 4]], dtype=object)
         )
     with pytest.raises(ValueError):
         # elevation is greater than 90
-        tau2021sse_nigens.validate_locations(
+        annotations.validate_locations(
             np.array([[91, 5, None], [2, 3, None]], dtype=object)
         )
     with pytest.raises(ValueError):
         # elevation is greater than 181
-        tau2021sse_nigens.validate_locations(
+        annotations.validate_locations(
             np.array([[90, 181, None], [2, 3, None]], dtype=object)
         )
 


### PR DESCRIPTION
This PR involves the extraction of the 'Spatial Event' class from the STARSS codebase and from TAU SSE for the years 2019, 2020, and 2021. The class has been relocated to annotations.py. Furthermore, the validation processes have been restructured to utilize this constructed class effectively.