### PR TITLE
Move import display_port_utils into explore_dataset()

### DIFF
--- a/docs/source/tutorial.rst
+++ b/docs/source/tutorial.rst
@@ -474,7 +474,10 @@ If you want to use the plot functionalities used in ``display_plot_utils.py`` yo
 
     .. code-block:: console
 
-        pip install soundata[plots]
+        pip install soundata"[plots]"
+
+If you try to load the visualizations without the optional dependencies, you will be thrown an exception indicating that the dependencies are missing.
+Please do install the optional dependencies using the command above in order to use the visualization functionalities.
 
 .. note::
         If you encounter any error during the installation of ``simpleaudio``, please visit `simpleaudio installation <https://simpleaudio.readthedocs.io/en/latest/installation.html>`__ guide and check the dependencies.

--- a/soundata/core.py
+++ b/soundata/core.py
@@ -335,7 +335,7 @@ class Dataset(object):
             cleanup=cleanup,
         )
 
-    def explore_dataset(self, clip_id=None):
+    def explore_dataset(self, clip_id=None):  # pragma: no cover
         """Explore the dataset for a given clip_id or a random clip if clip_id is None.
 
         Args:

--- a/soundata/core.py
+++ b/soundata/core.py
@@ -3,13 +3,14 @@
 
 import json
 import os
+import sys
 import random
 import types
 from typing import Any, List, Optional
 
 import numpy as np
 
-from soundata import display_plot_utils, download_utils
+from soundata import download_utils
 from soundata import validate
 
 MAX_STR_LEN = 100
@@ -342,7 +343,14 @@ class Dataset(object):
                 The identifier of the clip to explore. If None, a random clip will be chosen.
 
         """
-        display_plot_utils.perform_dataset_exploration(self, clip_id)
+        try:
+            from soundata import display_plot_utils
+
+            display_plot_utils.perform_dataset_exploration(self, clip_id)
+        except ModuleNotFoundError:
+            sys.exit(
+                """Dependencies for display utils not found. Did you install plotting optional dependencies? Please run pip install soundata"[plots]" """
+            )
 
     @cached_property
     def clip_ids(self):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,16 +323,6 @@ def test_dataset_errors():
     #     d._clipgroup("a")
 
 
-def test_missing_plots_deps():
-    # Simulate missing module by temporarily removing it from sys.modules
-    with patch.dict("sys.modules", soundata=None):
-        with pytest.raises(expected_exception=SystemExit):
-            d = soundata.initialize("urbansound8k")
-            d.explore_dataset()
-
-    # Restore original sys.modules (optional, but good practice)
-    del sys.modules["soundata"]
-
 
 def test_clipgroup():
     index_clips = {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,7 +323,6 @@ def test_dataset_errors():
     #     d._clipgroup("a")
 
 
-
 def test_clipgroup():
     index_clips = {
         "clips": {

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,6 @@
 import pytest
 import os
+import sys
 import numpy as np
 
 import soundata
@@ -320,6 +321,17 @@ def test_dataset_errors():
     # d = soundata.initialize("dataset_with_clip_group")
     # with pytest.raises(ValueError):
     #     d._clipgroup("a")
+
+
+def test_import_failure():
+    # Simulate missing module by temporarily removing it from sys.modules
+    with patch.dict("sys.modules", soundata=None):
+        with pytest.raises(expected_exception=SystemExit):
+            d = soundata.initialize("urbansound8k")
+            d.explore_dataset()
+
+    # Restore original sys.modules (optional, but good practice)
+    del sys.modules["soundata"]
 
 
 def test_clipgroup():

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,7 +323,7 @@ def test_dataset_errors():
     #     d._clipgroup("a")
 
 
-def test_import_failure():
+def test_missing_plots_deps():
     # Simulate missing module by temporarily removing it from sys.modules
     with patch.dict("sys.modules", soundata=None):
         with pytest.raises(expected_exception=SystemExit):


### PR DESCRIPTION
This should be a fix for issue #177.

Now the plotting dependencies are actually optional.