### PR TITLE
Fixing Error in download_utils.py

### DIFF
--- a/soundata/download_utils.py
+++ b/soundata/download_utils.py
@@ -5,7 +5,7 @@ import logging
 import os
 import shutil
 import tarfile
-import urllib
+import urllib.request
 import zipfile
 import subprocess
 import py7zr


### PR DESCRIPTION
This PR fixes error #202 , which is showing attribute error from `download_utils.py`. After JAMS update, this error occur while testing the loader in local, which says 

> module 'urllib' has no attribute 'request'

Editing `import urllib `to `import urllib.request` fixes this bug. 