### PR TITLE
Migrate to correct datetime interface

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -22,7 +22,7 @@ sys.path.insert(0, os.path.abspath("../"))
 # -- Project information -----------------------------------------------------
 
 project = "soundata"
-year = datetime.datetime.utcnow().year
+year = datetime.datetime.now(datetime.timezone.utc).year
 copyright = '2021-{}, Soundata development team'.format(year)
 author = "The Soundata development team"
 


### PR DESCRIPTION
# PR Summary
This small PR resolves the annoying `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcnow() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.now(datetime.UTC). or datetime.datetime.utcnow()
```