### PR TITLE
Fix Checksum Error in ESC50

### DIFF
--- a/soundata/datasets/esc50.py
+++ b/soundata/datasets/esc50.py
@@ -96,10 +96,10 @@ INDEXES = {
 
 REMOTES = {
     "all": download_utils.RemoteFileMetadata(
-        filename="ESC-50-master.zip",
-        url="https://github.com/karoldvl/ESC-50/archive/master.zip",
-        checksum="7771e4b9d86d0945acce719c7a59305a",
-        unpack_directories=["ESC-50-master"],
+        filename="ESC-50-33c8ce9eb2cf0b1c2f8bcf322eb349b6be34dbb6.zip",
+        url="https://github.com/karoldvl/ESC-50/archive/33c8ce9eb2cf0b1c2f8bcf322eb349b6be34dbb6.zip",
+        checksum="071b44018315e034b2c6e8064543d19c",
+        unpack_directories=["ESC-50-33c8ce9eb2cf0b1c2f8bcf322eb349b6be34dbb6"],
     ),
 }
 


### PR DESCRIPTION
Fixes #208 

**Problem:**
The `ESC-50` loader was originally using a remote download link that pointed to the master branch of the `ESC-50` GitHub repository. Since the ZIP file is generated from the latest commit, any update to the repo (even just updating the README.md) would change the checksum, which occur checksum mismatch error in `Soundata`.

**Solution:**
To avoid this issue, this PR updates the remote link to point to a specific commit hash instead of the `master` branch. This way, the downloaded ZIP always comes from the same commit, so the checksum stays consistent and prevents the checksum errors even though the `ESC-50` dataset repo gets updated. 

