### PR TITLE
Fix Download Instructions not displaying in Google Colab

### DIFF
--- a/soundata/download_utils.py
+++ b/soundata/download_utils.py
@@ -108,19 +108,19 @@ def downloader(
             objs_to_download = list(remotes.keys())
 
         if "index" in objs_to_download and len(objs_to_download) > 1:
-            logging.info(
+            logging.warning(
                 "Downloading {}. Index is being stored in {}, and the rest of files in {}".format(
                     objs_to_download, index.indexes_dir, save_dir
                 )
             )
         elif "index" in objs_to_download and len(objs_to_download) == 1:
-            logging.info(
+            logging.warning(
                 "Downloading {}. Index is being stored in {}".format(
                     objs_to_download, index.indexes_dir
                 )
             )
         else:
-            logging.info("Downloading {} to {}".format(objs_to_download, save_dir))
+            logging.warning("Downloading {} to {}".format(objs_to_download, save_dir))
 
         for k in objs_to_download:
             if isinstance(remotes[k], list):
@@ -132,7 +132,7 @@ def downloader(
                     raise NotImplementedError("Only multipart zip supported.")
 
             else:
-                logging.info("[{}] downloading {}".format(k, remotes[k].filename))
+                logging.warning("[{}] downloading {}".format(k, remotes[k].filename))
                 extension = os.path.splitext(remotes[k].filename)[-1]
                 if ".zip" in extension:
                     download_zip_file(remotes[k], save_dir, force_overwrite, cleanup)
@@ -155,7 +155,7 @@ def downloader(
                         source_dir = os.path.join(destination_dir, src_dir)
 
                         if not os.path.exists(source_dir):
-                            logging.info(
+                            logging.warning(
                                 "Data not downloaded, because it probably already exists on your computer. "
                                 + "Run .validate() to check, or rerun with force_overwrite=True to delete any "
                                 + "existing files and download from scratch"
@@ -165,7 +165,7 @@ def downloader(
                         move_directory_contents(source_dir, destination_dir)
 
     if info_message is not None:
-        logging.info(info_message.format(save_dir))
+        logging.warning(info_message.format(save_dir))
 
 
 class DownloadProgressBar(tqdm):
@@ -267,7 +267,7 @@ def download_from_remote(remote, save_dir, force_overwrite):
                 logging.error(error_msg)
                 raise exc
     else:
-        logging.info(
+        logging.warning(
             "{} already exists and will not be downloaded. ".format(download_path)
             + "Rerun with force_overwrite=True to delete this file and force the download."
         )
@@ -413,7 +413,7 @@ def move_directory_contents(source_dir, target_dir):
     for fpath in directory_contents:
         target_path = os.path.join(target_dir, os.path.basename(fpath))
         if os.path.exists(target_path):
-            logging.info(
+            logging.warning(
                 "{} already exists. Run with force_overwrite=True to download from scratch".format(
                     target_path
                 )

--- a/soundata/validate.py
+++ b/soundata/validate.py
@@ -32,7 +32,7 @@ def log_message(message, verbose=True):
 
     """
     if verbose:
-        logging.info(message)
+        logging.warning(message)
 
 
 def validate(local_path, checksum):

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -632,7 +632,7 @@ def test_extractall_cp437(mocker, mock_download_from_remote, mock_unzip):
 
 
 def test_download_from_remote_already_exists(tmpdir, mocker):
-   
+
     filename = "a"
     save_dir = str(tmpdir)
     file_path = os.path.join(save_dir, filename)
@@ -642,12 +642,13 @@ def test_download_from_remote_already_exists(tmpdir, mocker):
     remote = download_utils.RemoteFileMetadata(
         filename=filename,
         url="b",
-        checksum="c", 
+        checksum="c",
     )
 
     # Mock md5 to return the expected checksum
     mocker.patch("soundata.download_utils.md5", return_value=remote.checksum)
 
-    
-    result = download_utils.download_from_remote(remote, save_dir, force_overwrite=False)
+    result = download_utils.download_from_remote(
+        remote, save_dir, force_overwrite=False
+    )
     assert result == file_path

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -629,3 +629,25 @@ def test_extractall_cp437(mocker, mock_download_from_remote, mock_unzip):
         true_file_location = os.path.join("tests", "resources", true_file)
         os.remove(true_file_location)
     shutil.rmtree(os.path.join("tests", "resources", "__MACOSX"))
+
+
+def test_download_from_remote_already_exists(tmpdir, mocker):
+   
+    filename = "a"
+    save_dir = str(tmpdir)
+    file_path = os.path.join(save_dir, filename)
+    with open(file_path, "w") as f:
+        f.write("dummy data")
+
+    remote = download_utils.RemoteFileMetadata(
+        filename=filename,
+        url="b",
+        checksum="c", 
+    )
+
+    # Mock md5 to return the expected checksum
+    mocker.patch("soundata.download_utils.md5", return_value=remote.checksum)
+
+    
+    result = download_utils.download_from_remote(remote, save_dir, force_overwrite=False)
+    assert result == file_path

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -631,24 +631,55 @@ def test_extractall_cp437(mocker, mock_download_from_remote, mock_unzip):
     shutil.rmtree(os.path.join("tests", "resources", "__MACOSX"))
 
 
-def test_download_from_remote_already_exists(tmpdir, mocker):
-
-    filename = "a"
-    save_dir = str(tmpdir)
-    file_path = os.path.join(save_dir, filename)
-    with open(file_path, "w") as f:
-        f.write("dummy data")
-
-    remote = download_utils.RemoteFileMetadata(
-        filename=filename,
-        url="b",
-        checksum="c",
+def test_unpack_directories_source_not_exists(mocker, mock_path):
+    mock_download_from_remote = mocker.patch.object(
+        download_utils, "download_from_remote"
     )
-
-    # Mock md5 to return the expected checksum
-    mocker.patch("soundata.download_utils.md5", return_value=remote.checksum)
-
-    result = download_utils.download_from_remote(
-        remote, save_dir, force_overwrite=False
+    mock_unzip = mocker.patch.object(download_utils, "unzip")
+    
+    # Create a remote with unpack_directories
+    zip_remote = download_utils.RemoteFileMetadata(
+        filename="test.zip", 
+        url="http://example.com", 
+        checksum="1234",
+        unpack_directories=["nonexistent_dir"]
     )
-    assert result == file_path
+    
+    index = core.Index("test.json")
+    
+    # Mock os.path.exists to return False for the source directory
+    mock_exists = mocker.patch('os.path.exists')
+    # First call for save_dir creation should return True
+    # Second call for source_dir should return False
+    mock_exists.side_effect = [True, False]
+    
+    # Call downloader - this should trigger the warning and early return
+    download_utils.downloader("test_dir", index=index, remotes={"test": zip_remote})
+    
+    # Verify that download_from_remote and unzip were called
+    mock_download_from_remote.assert_called_once()
+    mock_unzip.assert_called_once()
+    
+    # Verify that os.path.exists was called for the source directory
+    assert mock_exists.call_count >= 2
+
+
+def test_move_directory_contents_target_exists(tmpdir):
+    
+    # Create source directory with a file
+    source_dir = tmpdir.mkdir("source")
+    source_file = source_dir.join("test.txt")
+    source_file.write("source content")
+    
+    # Create target directory with a file of the same name
+    target_dir = tmpdir.mkdir("target")
+    target_file = target_dir.join("test.txt")
+    target_file.write("target content")
+    
+    # Call move_directory_contents - should log warning and continue
+    download_utils.move_directory_contents(str(source_dir), str(target_dir))
+    
+    # Verify source directory was removed (this is expected behavior)
+    assert not source_dir.exists()
+    # Verify target file still has original content (wasn't overwritten)
+    assert target_file.read() == "target content"

--- a/tests/test_download_utils.py
+++ b/tests/test_download_utils.py
@@ -636,49 +636,49 @@ def test_unpack_directories_source_not_exists(mocker, mock_path):
         download_utils, "download_from_remote"
     )
     mock_unzip = mocker.patch.object(download_utils, "unzip")
-    
+
     # Create a remote with unpack_directories
     zip_remote = download_utils.RemoteFileMetadata(
-        filename="test.zip", 
-        url="http://example.com", 
+        filename="test.zip",
+        url="http://example.com",
         checksum="1234",
-        unpack_directories=["nonexistent_dir"]
+        unpack_directories=["nonexistent_dir"],
     )
-    
+
     index = core.Index("test.json")
-    
+
     # Mock os.path.exists to return False for the source directory
-    mock_exists = mocker.patch('os.path.exists')
+    mock_exists = mocker.patch("os.path.exists")
     # First call for save_dir creation should return True
     # Second call for source_dir should return False
     mock_exists.side_effect = [True, False]
-    
+
     # Call downloader - this should trigger the warning and early return
     download_utils.downloader("test_dir", index=index, remotes={"test": zip_remote})
-    
+
     # Verify that download_from_remote and unzip were called
     mock_download_from_remote.assert_called_once()
     mock_unzip.assert_called_once()
-    
+
     # Verify that os.path.exists was called for the source directory
     assert mock_exists.call_count >= 2
 
 
 def test_move_directory_contents_target_exists(tmpdir):
-    
+
     # Create source directory with a file
     source_dir = tmpdir.mkdir("source")
     source_file = source_dir.join("test.txt")
     source_file.write("source content")
-    
+
     # Create target directory with a file of the same name
     target_dir = tmpdir.mkdir("target")
     target_file = target_dir.join("test.txt")
     target_file.write("target content")
-    
+
     # Call move_directory_contents - should log warning and continue
     download_utils.move_directory_contents(str(source_dir), str(target_dir))
-    
+
     # Verify source directory was removed (this is expected behavior)
     assert not source_dir.exists()
     # Verify target file still has original content (wasn't overwritten)


### PR DESCRIPTION
This PR is replicated from Mirdata, PR [#680](https://github.com/mir-dataset-loaders/mirdata/pull/680)

Descriptions are also from Mirdata PR. 

**Problem:**
When using mirdata in Google Colab notebooks, download progress messages and download instructions are not displayed in the cell output. This happens because:

1. Google Colab's root logger is configured to WARNING level by default
2. soundata;s download messages are logged at INFO level (see download_utils.py line 18: `logging.basicConfig(format="%(levelname)s: %(message)s", level=logging.INFO)`)
3. The actual download progress messages use `logging.warning()` but the download instructions (`DOWNLOAD_INFO`) use the INFO level through `info_message` parameter

**Current Behavior:**
In Google Colab, users don't see:
- Download instructions that explain how to manually download datasets
- Progress information about what's being downloaded

**Expected Behavior:**
Users should see download messages and instructions in Google Colab cell output, just like they do in local environments.

**Proposed Solution:**
Changed the logging level for download messages from INFO to WARNING level.
1. Updated all download-related log messages that currently use `logging.info()` to use `logging.warning()`
2. Ensuring that `info_message` (which contains `DOWNLOAD_INFO`) is logged at WARNING level

**Files to Review:**
- download_utils.py - Contains the logging configuration and download message logic
- Dataset files (guitarset) that define `DOWNLOAD_INFO` constants

**Environment:**
- Platform: Google Colab
- Issue: Root logger set to WARNING level, mirdata uses INFO level

This change would improve the user experience in Google Colab without affecting functionality in other environments.