### PR TITLE
Fixing index partial download being duplicated

### DIFF
--- a/soundata/display_plot_utils.py
+++ b/soundata/display_plot_utils.py
@@ -293,7 +293,7 @@ def plot_distribution(data, title, x_label, y_label, axes, subplot_position):
     my_palette = ["#404040", "#126782", "#C9C9C9"]
     sns.countplot(
         y=data,
-        order=pd.value_counts(data).index,
+        order=pd.Series(data).value_counts().index,
         palette=my_palette,
         ax=axes[subplot_position],
     )

--- a/soundata/download_utils.py
+++ b/soundata/download_utils.py
@@ -104,7 +104,7 @@ def downloader(
                     )
                 )
             objs_to_download = partial_download
-            if "index" in remotes.keys():
+            if "index" in remotes.keys() and "index" not in objs_to_download:
                 objs_to_download.append("index")
         else:
             objs_to_download = list(remotes.keys())

--- a/tests/test_display_plot_utils.py
+++ b/tests/test_display_plot_utils.py
@@ -639,8 +639,8 @@ def test_update_line_exception():
 
 
 @patch("soundata.display_plot_utils.sns.countplot")
-@patch("soundata.display_plot_utils.pd.value_counts")
-def test_plot_distribution(mock_value_counts, mock_countplot):
+@patch("soundata.display_plot_utils.pd.Series")
+def test_plot_distribution(mock_series, mock_countplot):
     # Mock patches for the plot
     mock_patches = []
     for _ in range(3):  # Assuming three patches for simplicity
@@ -658,14 +658,15 @@ def test_plot_distribution(mock_value_counts, mock_countplot):
     axes = [MagicMock(), MagicMock()]
     axes[0].patches = mock_patches
 
-    # Mock value_counts to return a specific order
-    mock_value_counts.return_value.index = ["A", "B", "C"]
+    # Mock pd.Series(data).value_counts() to return a specific order
+    mock_series.return_value.value_counts.return_value.index = ["A", "B", "C"]
 
     # Call the function
     display_plot_utils.plot_distribution(data, title, x_label, y_label, axes, 0)
 
     # Assertions
-    mock_value_counts.assert_called_with(data)
+    mock_series.assert_called_with(data)
+    mock_series.return_value.value_counts.assert_called_once()
     mock_countplot.assert_called_with(
         y=data,
         order=["A", "B", "C"],


### PR DESCRIPTION
### Pull request name 

Fixing index partial download being duplicated

### Description

Currently, if we run  `partial_download=[index]`, downloading `index` was being duplicated.

>d = soundata.initialize('esc50')
d.download(partial_download=['index'])
INFO: Downloading ['index', 'index']. Index is being stored in /Users/yujinkim/git_repo/soundata/soundata/datasets/indexes, and the rest of files in /Users/yujinkim/sound_datasets/esc50
INFO: [index] downloading esc50_index_2.0.json
264kB [00:01, 177kB/s]                                                                                                                             
INFO: [index] downloading esc50_index_2.0.json
INFO: /Users/yujinkim/git_repo/soundata/soundata/datasets/indexes/esc50_index_2.0.json already exists and will not be downloaded. Rerun with force_overwrite=True to delete this file and force the download.

This was happening because the `index` was always appended to `objs_to_download`, even if the `index` was present in `partial download`. 

### Type of change

- [x] Add a guard to only append "index" if it's not present in `objs_to_download`.


[UPDATE] Also fixes an update from the pandas dependency
