### PR TITLE
Black update - formatting, Removing pytest-pep8 from dependencies

### DIFF
--- a/.github/environment-ci.yml
+++ b/.github/environment-ci.yml
@@ -14,7 +14,6 @@ dependencies:
 
   # optional, but required for testing.
   - pytest>=7.2.0
-  - pytest-pep8>=1.0.6
   - pytest-cov>=4.1.0
   - pytest-mock>=3.10.0
   - pytest-localserver>=0.7.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,7 +51,6 @@ tests = [
     "requests>=2.31.0",
     "pytest>=7.2.0",
     "pytest-cov>=4.1.0",
-    "pytest-pep8>=1.0.6",
     "pytest-mock>=3.10.0",
     "pytest-localserver>=0.7.1",
     "pytest-xdist>=2.3.0",

--- a/soundata/__init__.py
+++ b/soundata/__init__.py
@@ -4,7 +4,6 @@ import pkgutil
 
 from .version import version as __version__
 
-
 DATASETS = [
     d.name
     for d in pkgutil.iter_modules(

--- a/soundata/datasets/clotho.py
+++ b/soundata/datasets/clotho.py
@@ -73,7 +73,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @INPROCEEDINGS{9052990,
   author={Drossos, Konstantinos and Lipping, Samuel and Virtanen, Tuomas},

--- a/soundata/datasets/dcase23_task2.py
+++ b/soundata/datasets/dcase23_task2.py
@@ -56,7 +56,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @article{harada2023firstshot,
   title={First-shot anomaly detection for machine condition monitoring: A domain generalization baseline},

--- a/soundata/datasets/dcase23_task4b.py
+++ b/soundata/datasets/dcase23_task4b.py
@@ -70,7 +70,6 @@ import csv
 import numpy as np
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @article{Martinmorato2023,
     author = "Martín-Morató, Irene and Mesaros, Annamaria",

--- a/soundata/datasets/dcase_bioacoustic.py
+++ b/soundata/datasets/dcase_bioacoustic.py
@@ -82,7 +82,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @dataset{nolasco_ines_2022_6482837,
   author       = {Nolasco, Ines and

--- a/soundata/datasets/dcase_birdVox20k.py
+++ b/soundata/datasets/dcase_birdVox20k.py
@@ -67,7 +67,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @inproceedings{lostanlen2018icassp,
   title = {BirdVox-full-night: a dataset and benchmark for avian flight call detection},

--- a/soundata/datasets/esc50.py
+++ b/soundata/datasets/esc50.py
@@ -67,7 +67,6 @@ import csv
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @inproceedings{piczak2015dataset,
   title = {{ESC}: {Dataset} for {Environmental Sound Classification}},

--- a/soundata/datasets/freefield1010.py
+++ b/soundata/datasets/freefield1010.py
@@ -50,7 +50,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @inproceedings{Stowell:2014f,
   title = {freefield1010 - an open dataset for research on audio field recording archives},

--- a/soundata/datasets/fsd50k.py
+++ b/soundata/datasets/fsd50k.py
@@ -200,7 +200,6 @@ import numpy as np
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @dataset{fonseca2020fsd50k,
     title={FSD50K: an Open Dataset of Human-Labeled Sound Events}, 

--- a/soundata/datasets/fsdnoisy18k.py
+++ b/soundata/datasets/fsdnoisy18k.py
@@ -118,7 +118,6 @@ import numpy as np
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @misc{fonseca2019learning,
       title={Learning Sound Event Classifiers from Web Audio with Noisy Labels},

--- a/soundata/datasets/tau2019uas.py
+++ b/soundata/datasets/tau2019uas.py
@@ -228,7 +228,6 @@ import csv
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @inproceedings{Mesaros:DCASE:18,
     Address = {Surrey, UK},

--- a/soundata/datasets/tau2020uas_mobile.py
+++ b/soundata/datasets/tau2020uas_mobile.py
@@ -580,7 +580,6 @@ import csv
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @inproceedings{Heittola:DCASE:20,
     Address = {Tokyo, Japan},

--- a/soundata/datasets/tau2022uas_mobile.py
+++ b/soundata/datasets/tau2022uas_mobile.py
@@ -582,7 +582,6 @@ import csv
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @inproceedings{Heittola:DCASE:20,
     Address = {Tokyo, Japan},

--- a/soundata/datasets/tut2017se.py
+++ b/soundata/datasets/tut2017se.py
@@ -164,7 +164,6 @@ import csv
 
 from soundata import download_utils, core, annotations, io
 
-
 BIBTEX = """
 @inproceedings{Mesaros:DCASE:17,
     Address = {Munich, Germany},

--- a/soundata/datasets/urbansed.py
+++ b/soundata/datasets/urbansed.py
@@ -133,7 +133,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @inproceedings{Salamon:Scaper:WASPAA:17,
 	Address = {New Paltz, NY, USA},

--- a/soundata/datasets/urbansound8k.py
+++ b/soundata/datasets/urbansound8k.py
@@ -138,7 +138,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @inproceedings{Salamon:UrbanSound:ACMMM:14,
 	Address = {Orlando, FL, USA},

--- a/soundata/datasets/warblrb10k.py
+++ b/soundata/datasets/warblrb10k.py
@@ -59,7 +59,6 @@ from soundata import core
 from soundata import annotations
 from soundata import io
 
-
 BIBTEX = """
 @article{article,
 author = {Stowell, Dan and Wood, Michael and Pamuła, Hanna and Stylianou, Yannis and Glotin, Hervé},

--- a/soundata/download_utils.py
+++ b/soundata/download_utils.py
@@ -263,9 +263,7 @@ def download_from_remote(remote, save_dir, force_overwrite):
                             If this error persists, please raise an issue at
                             https://github.com/soundata/soundata,
                             and tag it with 'broken-link'.
-                            """.format(
-                    remote.url
-                )
+                            """.format(remote.url)
                 logging.error(error_msg)
                 raise exc
     else:

--- a/tests/datasets/test_dcase23_task2.py
+++ b/tests/datasets/test_dcase23_task2.py
@@ -7,7 +7,6 @@ from tests.test_utils import run_clip_tests
 from soundata import annotations
 from soundata.datasets import dcase23_task2
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/dcase23_task2")
 
 

--- a/tests/datasets/test_dcase_bioacoustic.py
+++ b/tests/datasets/test_dcase_bioacoustic.py
@@ -6,7 +6,6 @@ from tests.test_utils import run_clip_tests
 from soundata import annotations
 from soundata.datasets import dcase_bioacoustic
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/dcase_bioacoustic")
 
 

--- a/tests/datasets/test_dcase_birdVox20k.py
+++ b/tests/datasets/test_dcase_birdVox20k.py
@@ -7,7 +7,6 @@ from soundata import annotations
 from soundata.datasets import dcase_birdVox20k
 from tests.test_utils import DEFAULT_DATA_HOME
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/dcase_birdVox20k")
 
 

--- a/tests/datasets/test_eigenscape.py
+++ b/tests/datasets/test_eigenscape.py
@@ -6,7 +6,6 @@ from soundata import annotations
 from soundata.datasets import eigenscape
 import os
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/eigenscape")
 
 

--- a/tests/datasets/test_freefield1010.py
+++ b/tests/datasets/test_freefield1010.py
@@ -7,7 +7,6 @@ from soundata import annotations
 from soundata.datasets import freefield1010
 from tests.test_utils import DEFAULT_DATA_HOME
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/freefield1010")
 
 

--- a/tests/datasets/test_tau2019sse.py
+++ b/tests/datasets/test_tau2019sse.py
@@ -7,7 +7,6 @@ from tests.test_utils import run_clip_tests
 from soundata import annotations
 from soundata.datasets import tau2019sse
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/tau2019sse")
 
 

--- a/tests/datasets/test_tau2020sse_nigens.py
+++ b/tests/datasets/test_tau2020sse_nigens.py
@@ -7,7 +7,6 @@ from tests.test_utils import run_clip_tests, DEFAULT_DATA_HOME
 from soundata import annotations
 from soundata.datasets import tau2020sse_nigens
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/tau2020sse_nigens")
 
 

--- a/tests/datasets/test_urbansed.py
+++ b/tests/datasets/test_urbansed.py
@@ -6,7 +6,6 @@ from tests.test_utils import run_clip_tests
 from soundata import annotations
 from soundata.datasets import urbansed
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/urbansed")
 
 

--- a/tests/datasets/test_urbansound8k.py
+++ b/tests/datasets/test_urbansound8k.py
@@ -7,7 +7,6 @@ from soundata import annotations
 from soundata.datasets import urbansound8k
 from tests.test_utils import DEFAULT_DATA_HOME
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/urbansound8k")
 
 

--- a/tests/datasets/test_warblrb10k.py
+++ b/tests/datasets/test_warblrb10k.py
@@ -7,7 +7,6 @@ from soundata import annotations
 from soundata.datasets import warblrb10k
 from tests.test_utils import DEFAULT_DATA_HOME
 
-
 TEST_DATA_HOME = os.path.normpath("tests/resources/sound_datasets/warblrb10k")
 
 


### PR DESCRIPTION
Due to the recent `Black` update, this PR updates all the loaders with new formatting.

[UPDATES]
**pytest** loads the **pytest-pep8** automatically, which is no longer compatible with **pytest 9**, and it rejects its outdate `pytest_collect_file(path, parent)` hook signature.
This makes **pytest** fail before any tests run.

**Soundata** already uses flake8 for style checks, and currently, test does not use **pytest-pep8**. So **pytest-pep8** is no longer needed.

* `pytest-pep8` removed from dependencies

### Notes
CI error regarding `pandas` is addressed in #220